### PR TITLE
refactor: remove db calls from the AI layer

### DIFF
--- a/ai/chatter.go
+++ b/ai/chatter.go
@@ -13,7 +13,7 @@ const PedroPrompt = "Your name is Pedro. You are a chat bot that helps out in So
 
 // Chattter is the interface that defines the functions that Pedro will have. The interface is implemented with functionally for each connection.
 type Chatter interface {
-	SingleMessageResponse(ctx context.Context, msg database.TwitchMessage, messageID uuid.UUID) (string, error)
+	SingleMessageResponse(ctx context.Context, msg database.TwitchMessage, messageID uuid.UUID) (database.TwitchMessage, error)
 	Play20Questions(ctx context.Context, msg database.TwitchMessage, messageID uuid.UUID) (string, error)
 	End20Questions()
 }

--- a/ai/discordchat/ask.go
+++ b/ai/discordchat/ask.go
@@ -12,12 +12,12 @@ import (
 )
 
 // SingleMessageResponse is a response from the LLM model to a single message
-func (b *Bot) SingleMessageResponse(ctx context.Context, msg database.TwitchMessage, messageID uuid.UUID) (string, error) {
+func (b *Bot) SingleMessageResponse(ctx context.Context, msg database.TwitchMessage, messageID uuid.UUID) (database.TwitchMessage, error) {
 	b.logger.Debug("processing discord single message response", "messageID", messageID)
 
 	messageHistory := []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeSystem, ai.PedroPrompt)}
 	messageHistory = append(messageHistory, llms.TextParts(llms.ChatMessageTypeHuman, msg.Text))
-	
+
 	b.logger.Debug("calling LLM for discord message", "messageID", messageID)
 	resp, err := b.llm.GenerateContent(context.Background(), messageHistory,
 		llms.WithCandidateCount(1),
@@ -28,26 +28,26 @@ func (b *Bot) SingleMessageResponse(ctx context.Context, msg database.TwitchMess
 	if err != nil {
 		b.logger.Error("failed to get discord LLM response", "error", err.Error(), "messageID", messageID)
 		metrics.FailedLLMGen.Add(1)
-		return "", fmt.Errorf("failed to get llm response: %w", err)
+		return database.TwitchMessage{}, fmt.Errorf("failed to get llm response: %w", err)
 	}
-	
+
 	prompt := ai.CleanResponse(resp.Choices[0].Content)
 	b.logger.Debug("received discord LLM response", "messageID", messageID, "responseLength", len(prompt))
-	
+
 	if prompt == "" {
 		b.logger.Warn("empty response from discord LLM", "messageID", messageID)
 		metrics.EmptyLLMResponse.Add(1)
 		// We are trying to tag the user to get them to try again with a better prompt.
-		return fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", msg.Username), nil
+		return database.TwitchMessage{
+			Text: fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", msg.Username),
+			UUID: messageID,
+		}, nil
 	}
 
-	// Insert the response into the database
-	if err = b.db.InsertResponse(ctx, resp, messageID, b.modelName); err != nil {
-		b.logger.Error("failed to insert discord response into database", "error", err.Error(), "messageID", messageID)
-		return prompt, fmt.Errorf("failed to insert response into database: %w", err)
-	}
-	
 	b.logger.Debug("successful discord response generation", "messageID", messageID, "messageLength", len(prompt))
 	metrics.SuccessfulLLMGen.Add(1)
-	return prompt, nil
+	return database.TwitchMessage{
+		Text: prompt,
+		UUID: messageID,
+	}, nil
 }

--- a/ai/twitchchat/llm_test.go
+++ b/ai/twitchchat/llm_test.go
@@ -26,12 +26,6 @@ func (m *mockLLM) Call(ctx context.Context, prompt string, opts ...llms.CallOpti
 	return "", nil
 }
 
-type mockDB struct{}
-
-func (m *mockDB) InsertResponse(ctx context.Context, resp *llms.ContentResponse, messageID uuid.UUID, modelName string) error {
-	return nil
-}
-
 func TestClient_callLLM(t *testing.T) {
 	type args struct {
 		ctx       context.Context
@@ -48,7 +42,6 @@ func TestClient_callLLM(t *testing.T) {
 			name: "make prompt",
 			c: Client{
 				llm:    &mockLLM{},
-				db:     &mockDB{},
 				logger: logging.Default(),
 			},
 			args: args{
@@ -102,7 +95,6 @@ func TestClient_manageChatHistory(t *testing.T) {
 			name: "no chat",
 			client: &Client{
 				llm:    &mockLLM{},
-				db:     &mockDB{},
 				logger: logging.Default(),
 			},
 			args: args{
@@ -116,7 +108,6 @@ func TestClient_manageChatHistory(t *testing.T) {
 			name: "some chat",
 			client: &Client{
 				llm:         &mockLLM{},
-				db:          &mockDB{},
 				chatHistory: chat3,
 				logger:      logging.Default(),
 			},
@@ -131,7 +122,6 @@ func TestClient_manageChatHistory(t *testing.T) {
 			name: "full chat",
 			client: &Client{
 				llm:         &mockLLM{},
-				db:          &mockDB{},
 				chatHistory: ch,
 				logger:      logging.Default(),
 			},

--- a/ai/twitchchat/setup.go
+++ b/ai/twitchchat/setup.go
@@ -4,7 +4,6 @@ package twitchchat
 import (
 	"fmt"
 
-	"github.com/Soypete/twitch-llm-bot/database"
 	"github.com/Soypete/twitch-llm-bot/logging"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
@@ -13,20 +12,18 @@ import (
 // Client is a client for interacting with the OpenAI LLM and the database.
 type Client struct {
 	llm         llms.Model
-	db          database.ResponseWriter
-	modelName   string
 	chatHistory []llms.MessageContent
 	logger      *logging.Logger
 }
 
 // Setup creates a new twitch chat bot.
-func Setup(db database.ResponseWriter, modelName string, llmPath string, logger *logging.Logger) (*Client, error) {
+func Setup(llmPath string, logger *logging.Logger) (*Client, error) {
 	if logger == nil {
 		logger = logging.Default()
 	}
-	
-	logger.Info("setting up twitch chat LLM client", "model", modelName, "path", llmPath)
-	
+
+	logger.Info("setting up twitch chat LLM client", "path", llmPath)
+
 	opts := []openai.Option{
 		openai.WithBaseURL(llmPath),
 	}
@@ -37,9 +34,7 @@ func Setup(db database.ResponseWriter, modelName string, llmPath string, logger 
 	}
 
 	return &Client{
-		llm:       llm,
-		db:        db,
-		modelName: modelName,
-		logger:    logger,
+		llm:    llm,
+		logger: logger,
 	}, nil
 }

--- a/database/message.go
+++ b/database/message.go
@@ -8,6 +8,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// ChatResponseWriter is an interface that allows for both storing twitch chat chatHistory
+// and Pedro's responses in the database.
+type ChatResponseWriter interface {
+	MessageWriter
+	ResponseWriter
+}
+
+// MessageWriter is an interface for inserting twitch chat messages into the database.
 type MessageWriter interface {
 	InsertMessage(ctx context.Context, msg TwitchMessage) (uuid.UUID, error)
 }
@@ -21,28 +29,25 @@ func (p *Postgres) InsertMessage(ctx context.Context, msg TwitchMessage) (uuid.U
 		return uuid.UUID{}, fmt.Errorf("error generating UUID: %w", err)
 	}
 	msg.UUID = ID
-	
+
 	query := "INSERT INTO twitch_chat (username, message, isCommand, created_at, uuid) VALUES (:username, :message, :isCommand, :created_at, :uuid)"
 	p.logger.Debug("inserting message into database", "messageID", ID)
-	
+
 	_, err = p.connections.NamedExecContext(ctx, query, msg)
 	if err != nil {
 		p.logger.Error("error inserting message into database", "error", err.Error(), "messageID", ID)
 		return uuid.UUID{}, fmt.Errorf("error inserting message: %w", err)
 	}
-	
+
 	p.logger.Debug("message inserted successfully", "messageID", ID)
 	return ID, nil
 }
 
-// TODO: I need to move this to a different file
-// and it should have a more generic name
-// like message. and then I can use the same struct
-// for the discord messages
 type TwitchMessage struct {
-	Username  string    `db:"username"`
-	Text      string    `db:"message"`
-	IsCommand bool      `db:"isCommand"`
-	Time      time.Time `db:"created_at"`
-	UUID      uuid.UUID `db:"uuid"`
+	Username   string    `db:"username"`
+	Text       string    `db:"message"`
+	IsCommand  bool      `db:"isCommand"`
+	StopReason string    `db:"stop_reason"`
+	Time       time.Time `db:"created_at"`
+	UUID       uuid.UUID `db:"uuid"`
 }

--- a/database/responses.go
+++ b/database/responses.go
@@ -3,34 +3,22 @@ package database
 import (
 	"context"
 	"fmt"
-
-	"github.com/google/uuid"
-	"github.com/tmc/langchaingo/llms"
 )
 
 type ResponseWriter interface {
-	InsertResponse(ctx context.Context, resp *llms.ContentResponse, messageID uuid.UUID, modelName string) error
+	InsertResponse(ctx context.Context, resp TwitchMessage, modelName string) error
 }
 
-func (p *Postgres) InsertResponse(ctx context.Context, resp *llms.ContentResponse, messageID uuid.UUID, modelName string) error {
-	p.logger.Debug("inserting LLM response into database", "messageID", messageID, "model", modelName, "choices", len(resp.Choices))
+func (p *Postgres) InsertResponse(ctx context.Context, resp TwitchMessage, modelName string) error {
+	p.logger.Debug("inserting LLM response into database", "messageID", resp.UUID, "model", modelName)
 
-	var isUsed bool
-	for i, choice := range resp.Choices {
-		if i == 0 {
-			isUsed = true
-		}
-
-		query := "INSERT INTO bot_response (model_name, response, stop_reason, was_successful, chat_id) VALUES ($1, $2, $3, $4, $5)"
-		_, err := p.connections.ExecContext(ctx, query, modelName, choice.Content, choice.StopReason, isUsed, messageID)
-		if err != nil {
-			p.logger.Error("error inserting response into database", "error", err.Error(), "messageID", messageID, "choice", i)
-			return fmt.Errorf("error upserting response: %w", err)
-		}
-
-		p.logger.Debug("response choice inserted", "messageID", messageID, "choice", i, "stopReason", choice.StopReason)
+	query := "INSERT INTO bot_response (model_name, response, stop_reason, was_successful, chat_id) VALUES ($1, $2, $3, $4, $5)"
+	_, err := p.connections.ExecContext(ctx, query, modelName, resp.Text, resp.StopReason, true, resp.UUID)
+	if err != nil {
+		p.logger.Error("error inserting response into database", "error", err.Error(), "messageID", resp.UUID)
+		return fmt.Errorf("error upserting response: %w", err)
 	}
 
-	p.logger.Debug("all response choices inserted successfully", "messageID", messageID)
+	p.logger.Debug("all response choices inserted successfully", "messageID", resp.UUID)
 	return nil
 }

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -93,7 +93,7 @@ func (d Client) askPedro(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		Text:     text,
 	}
 
-	//Insert the message into the database
+	// Insert the message into the database
 	messageID, err := d.db.InsertMessage(context.Background(), message)
 	if err != nil {
 		d.logger.Error("failed to insert message into database", "error", err.Error())
@@ -133,14 +133,14 @@ func (d Client) askPedro(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	if resp == "" {
+	if resp.Text == "" {
 		d.logger.Warn("empty response from LLM", "messageID", messageID)
-		resp = "Sorry, I cannot respond to that. Please try again."
+		resp.Text = "Sorry, I cannot respond to that. Please try again."
 	}
 
 	userNumber := i.Interaction.Member.User.ID
 	// TODO: break this in to a function we can test
-	msgText := fmt.Sprintf("<@%s>:\nQuestion: %s\nResponse: %s", userNumber, text, resp)
+	msgText := fmt.Sprintf("<@%s>:\nQuestion: %s\nResponse: %s", userNumber, text, resp.Text)
 	_, err = d.Session.ChannelMessageSend(i.Interaction.ChannelID, msgText)
 	if err != nil {
 		d.logger.Error("error sending message to channel", "error", err.Error(), "channelID", i.Interaction.ChannelID)

--- a/twitch/connection.go
+++ b/twitch/connection.go
@@ -17,28 +17,30 @@ const peteTwitchChannel = "soypetetech"
 
 // IRC Connection to the twitch IRC server.
 type IRC struct {
-	db       database.MessageWriter
-	wg       *sync.WaitGroup
-	Client   *v2.Client
-	tok      *oauth2.Token
-	llm      ai.Chatter
-	authCode string
-	logger   *logging.Logger
+	db        database.ChatResponseWriter
+	modelName string
+	wg        *sync.WaitGroup
+	Client    *v2.Client
+	tok       *oauth2.Token
+	llm       ai.Chatter
+	authCode  string
+	logger    *logging.Logger
 }
 
 // SetupTwitchIRC sets up the IRC, configures oauth, and inits connection functions.
-func SetupTwitchIRC(wg *sync.WaitGroup, llm ai.Chatter, db database.MessageWriter, logger *logging.Logger) (*IRC, error) {
+func SetupTwitchIRC(wg *sync.WaitGroup, llm ai.Chatter, modelName string, db database.ChatResponseWriter, logger *logging.Logger) (*IRC, error) {
 	if logger == nil {
 		logger = logging.Default()
 	}
-	
+
 	irc := &IRC{
-		db:     db,
-		wg:     wg,
-		llm:    llm,
-		logger: logger,
+		db:        db,
+		wg:        wg,
+		llm:       llm,
+		modelName: modelName,
+		logger:    logger,
 	}
-	
+
 	// using a separate context here because it needs human interaction
 	ctx := context.Background()
 	err := irc.AuthTwitch(ctx)

--- a/twitch/handleMessage.go
+++ b/twitch/handleMessage.go
@@ -76,6 +76,10 @@ func (irc *IRC) HandleChat(ctx context.Context, msg v2.PrivateMessage) {
 		}
 
 		err = irc.db.InsertResponse(ctx, resp, irc.modelName)
+		if err != nil {
+			irc.logger.Error("failed to insert response into database", "error", err.Error(), "messageID", resp.UUID)
+			// continue to send the response even if it fails to insert into the database
+		}
 		// Don't log the actual response content to protect privacy
 		irc.logger.Debug("sending response to Twitch", "messageID", resp.UUID, "responseLength", len(resp.Text))
 		irc.Client.Say("soypetetech", resp.Text)

--- a/twitch/handleMessage.go
+++ b/twitch/handleMessage.go
@@ -71,13 +71,14 @@ func (irc *IRC) HandleChat(ctx context.Context, msg v2.PrivateMessage) {
 		irc.logger.Debug("message inserted into database", "messageID", messageID)
 		resp, err := irc.llm.SingleMessageResponse(ctx, chat, messageID)
 		if err != nil {
-			irc.logger.Error("failed to get response from LLM", "error", err.Error(), "messageID", messageID)
+			irc.logger.Error("failed to get response from LLM", "error", err.Error(), "messageID", resp.UUID)
 			return
 		}
 
+		err = irc.db.InsertResponse(ctx, resp, irc.modelName)
 		// Don't log the actual response content to protect privacy
-		irc.logger.Debug("sending response to Twitch", "messageID", messageID, "responseLength", len(resp))
-		irc.Client.Say("soypetetech", resp)
+		irc.logger.Debug("sending response to Twitch", "messageID", resp.UUID, "responseLength", len(resp.Text))
+		irc.Client.Say("soypetetech", resp.Text)
 		metrics.TwitchMessageSentCount.Add(1)
 	}
 }

--- a/twitch/handleMessage.go
+++ b/twitch/handleMessage.go
@@ -71,8 +71,7 @@ func (irc *IRC) HandleChat(ctx context.Context, msg v2.PrivateMessage) {
 		irc.logger.Debug("message inserted into database", "messageID", messageID)
 		resp, err := irc.llm.SingleMessageResponse(ctx, chat, messageID)
 		if err != nil {
-			irc.logger.Error("failed to get response from LLM", "error", err.Error(), "messageID", resp.UUID)
-			return
+			irc.logger.Error("failed to get response from LLM", "error", err.Error(), "messageID", messageID)
 		}
 
 		err = irc.db.InsertResponse(ctx, resp, irc.modelName)


### PR DESCRIPTION
We want database calls to only be made in the message handling layers and not it the ai layer. The AI layer should only contain the necessary logic for talking to the LLM and the context needed for the LLM to respond to a specific audience. This is step 1 of the refactor that will allow us to break the twitch bot and discord bots into 2 disctinct apps.