### PR TITLE
fix: enforce HTTPS for all Twitch OAuth redirects

### DIFF
--- a/twitch/auth.go
+++ b/twitch/auth.go
@@ -41,12 +41,8 @@ func (irc *IRC) AuthTwitch(ctx context.Context) error {
 		redirectHost = "localhost:3000"
 	}
 
-	// Determine protocol based on redirect host
-	// Use HTTPS for Tailscale domains, HTTP for localhost
-	protocol := "http"
-	if redirectHost != "localhost:3000" && redirectHost != "127.0.0.1:3000" {
-		protocol = "https"
-	}
+	// Always use HTTPS for OAuth redirect
+	protocol := "https"
 
 	http.HandleFunc("/oauth/redirect", irc.parseAuthCode)
 	go func() {


### PR DESCRIPTION
Changed OAuth redirect URL to always use HTTPS protocol regardless of host configuration. Previously used HTTP for localhost which could cause security issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)