### PR TITLE
feat: add Grafana dashboards with auto-provisioning and rename metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ Key tables: `twitch_chat`, `bot_response`, `discord_ask_pedro`, `discord_twenty_
 ### Metrics and Monitoring
 - Prometheus metrics exposed on ports 6060/6061
 - Use `metrics.<MetricName>.Add(1)` to increment counters
-- Key metrics: `TwitchConnectionCount`, `TwitchMessageRecievedCount`, `SuccessfulLLMGen`, `FailedLLMGen`, `EmptyLLMResponse`
+- Key metrics: `TwitchConnectionCount`, `TwitchMessageRecievedCount`, `SuccessfulLLMGenCount`, `FailedLLMGenCount`, `EmptyLLMResponseCount`
 - Tracks message counts, LLM generation success/failure, response times
 - Structured logging with trace IDs for request correlation
 - `/healthz` endpoint available on all bots for health checks

--- a/README.md
+++ b/README.md
@@ -262,9 +262,9 @@ To trigger alerts for your demo:
 Pedro currently exposes these metrics (via expvar):
 
 **LLM/Bot Metrics (ports 6060/6061)**:
-- `successfull_llm_gen` - Number of successful LLM generations
-- `failed_llm_gen` - Number of failed LLM generations
-- `empty_llm_response` - Number of empty LLM responses
+- `successful_llm_gen_count` - Number of successful LLM generations
+- `failed_llm_gen_count` - Number of failed LLM generations
+- `empty_llm_response_count` - Number of empty LLM responses
 - `twitch_connection_count` - Number of Twitch connections established
 - `twitch_message_recieved_count` - Twitch messages received
 - `twitch_message_sent_count` - Twitch messages sent
@@ -283,12 +283,12 @@ Pedro currently exposes these metrics (via expvar):
 
 High LLM Error Rate:
 ```promql
-rate(failed_llm_gen[5m]) / (rate(successfull_llm_gen[5m]) + rate(failed_llm_gen[5m])) > 0.1
+rate(failed_llm_gen_count[5m]) / (rate(successful_llm_gen_count[5m]) + rate(failed_llm_gen_count[5m])) > 0.1
 ```
 
 High Empty Response Rate:
 ```promql
-rate(empty_llm_response[5m]) / rate(successfull_llm_gen[5m]) > 0.2
+rate(empty_llm_response_count[5m]) / rate(successful_llm_gen_count[5m]) > 0.2
 ```
 
 Web Search Failures:

--- a/ai/discordchat/20questions.go
+++ b/ai/discordchat/20questions.go
@@ -43,7 +43,7 @@ func (c *Bot) Start20Questions(ctx context.Context, msg types.Discord20Questions
 		llms.WithPresencePenalty(1.0)) // 2 is the largest penalty for using a work that has already been used
 	if err != nil {
 		c.logger.Error("failed to get 20 questions LLM response", "error", err.Error(), "messageID", msg.GameID)
-		metrics.FailedLLMGen.Add(1)
+		metrics.FailedLLMGenCount.Add(1)
 		return "", fmt.Errorf("failed to get llm response: %w", err)
 	}
 	return resp.Choices[0].Content, nil
@@ -60,7 +60,7 @@ func (c *Bot) Play20Questions(ctx context.Context, user string, gameChat []llms.
 		llms.WithPresencePenalty(1.0)) // 2 is the largest penalty for using a work that has already been used
 	if err != nil {
 		c.logger.Error("failed to get 20 questions LLM response", "error", err.Error())
-		metrics.FailedLLMGen.Add(1)
+		metrics.FailedLLMGenCount.Add(1)
 		return "", fmt.Errorf("failed to get llm response: %w", err)
 	}
 
@@ -69,11 +69,11 @@ func (c *Bot) Play20Questions(ctx context.Context, user string, gameChat []llms.
 
 	if prompt == "" {
 		c.logger.Warn("empty response from 20 questions LLM")
-		metrics.EmptyLLMResponse.Add(1)
+		metrics.EmptyLLMResponseCount.Add(1)
 		// We are trying to tag the user to get them to try again with a better prompt.
 		return fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", user), nil
 	}
 
-	metrics.SuccessfulLLMGen.Add(1)
+	metrics.SuccessfulLLMGenCount.Add(1)
 	return prompt, nil
 }

--- a/ai/discordchat/ask.go
+++ b/ai/discordchat/ask.go
@@ -35,7 +35,7 @@ func (b *Bot) SingleMessageResponse(ctx context.Context, msg types.DiscordAskMes
 		llms.WithStopWords([]string{"@pedro", "@Pedro", "@PedroAI", "@PedroAI_"}))
 	if err != nil {
 		b.logger.Error("failed to get discord LLM response", "error", err.Error(), "messageID", msg.ThreadID)
-		metrics.FailedLLMGen.Add(1)
+		metrics.FailedLLMGenCount.Add(1)
 		return nil, fmt.Errorf("failed to get llm response: %w", err)
 	}
 
@@ -44,7 +44,7 @@ func (b *Bot) SingleMessageResponse(ctx context.Context, msg types.DiscordAskMes
 
 	if prompt == "" {
 		b.logger.Warn("empty response from discord LLM", "messageID", msg.ThreadID)
-		metrics.EmptyLLMResponse.Add(1)
+		metrics.EmptyLLMResponseCount.Add(1)
 		// We are trying to tag the user to get them to try again with a better prompt.
 		return &types.DiscordResponse{
 			Text: fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", msg.Username),
@@ -79,7 +79,7 @@ func (b *Bot) SingleMessageResponse(ctx context.Context, msg types.DiscordAskMes
 	}
 
 	b.logger.Debug("successful discord response generation", "messageID", msg.ThreadID, "messageLength", len(prompt))
-	metrics.SuccessfulLLMGen.Add(1)
+	metrics.SuccessfulLLMGenCount.Add(1)
 	return &types.DiscordResponse{
 		Text: prompt,
 	}, nil
@@ -164,7 +164,7 @@ func (b *Bot) ThreadMessageResponse(ctx context.Context, msg types.DiscordAskMes
 		llms.WithStopWords([]string{"@pedro", "@Pedro", "@PedroAI", "@PedroAI_"}))
 	if err != nil {
 		b.logger.Error("failed to get discord thread LLM response", "error", err.Error(), "messageID", msg.MessageID)
-		metrics.FailedLLMGen.Add(1)
+		metrics.FailedLLMGenCount.Add(1)
 		return "", fmt.Errorf("failed to get llm response: %w", err)
 	}
 
@@ -173,11 +173,11 @@ func (b *Bot) ThreadMessageResponse(ctx context.Context, msg types.DiscordAskMes
 
 	if prompt == "" {
 		b.logger.Warn("empty response from discord thread LLM", "messageID", msg.MessageID)
-		metrics.EmptyLLMResponse.Add(1)
+		metrics.EmptyLLMResponseCount.Add(1)
 		return fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", msg.Username), nil
 	}
 
 	b.logger.Debug("successful discord thread response generation", "messageID", msg.MessageID, "messageLength", len(prompt))
-	metrics.SuccessfulLLMGen.Add(1)
+	metrics.SuccessfulLLMGenCount.Add(1)
 	return prompt, nil
 }

--- a/ai/twitchchat/llm.go
+++ b/ai/twitchchat/llm.go
@@ -62,13 +62,13 @@ func (c *Client) SingleMessageResponse(ctx context.Context, msg types.TwitchMess
 	prompt, err := c.callLLM(ctx, []string{fmt.Sprintf("%s: %s", msg.Username, msg.Text)}, messageID)
 	if err != nil {
 		c.logger.Error("failed to generate response", "error", err.Error(), "messageID", messageID)
-		metrics.FailedLLMGen.Add(1)
+		metrics.FailedLLMGenCount.Add(1)
 		return types.TwitchMessage{}, err
 	}
 
 	if prompt == "" {
 		c.logger.Warn("empty response from LLM", "messageID", messageID)
-		metrics.EmptyLLMResponse.Add(1)
+		metrics.EmptyLLMResponseCount.Add(1)
 		// We are trying to tag the user to get them to try again with a better prompt.
 		return types.TwitchMessage{
 			Text: fmt.Sprintf("sorry, I cannot respond to @%s. Please try again", msg.Username),
@@ -106,7 +106,7 @@ func (c *Client) SingleMessageResponse(ctx context.Context, msg types.TwitchMess
 	}
 
 	c.logger.Debug("successful response generation", "messageID", messageID, "messageLength", len(prompt))
-	metrics.SuccessfulLLMGen.Add(1)
+	metrics.SuccessfulLLMGenCount.Add(1)
 	return types.TwitchMessage{
 		Text: prompt,
 		UUID: messageID,

--- a/config/grafana/ALERTS-README.md
+++ b/config/grafana/ALERTS-README.md
@@ -1,0 +1,168 @@
+# Grafana Alert Rules Setup
+
+This directory contains pre-configured Grafana alert rules for monitoring Pedro bot services.
+
+## Quick Setup
+
+### 1. Set Up Discord Webhook (One Channel)
+
+1. Open your Discord server settings
+2. Go to **Integrations** → **Webhooks**
+3. Click **New Webhook**
+4. Name it "Pedro Alerts" and select your target channel (e.g., #pedro-alerts)
+5. Copy the webhook URL
+
+### 2. Configure Grafana Contact Point
+
+1. In Grafana, navigate to **Alerting** → **Contact points**
+2. Click **Add contact point**
+3. Set **Name**: `Pedro Discord Alerts`
+4. Set **Integration**: `Discord`
+5. Paste your webhook URL
+6. (Optional) To get tagged, add this to **Message** field:
+   ```
+   <@YOUR_USER_ID> {{ template "default.message" . }}
+   ```
+   To find your Discord user ID: Right-click your name → Copy ID (requires Developer Mode enabled)
+7. Click **Test** to verify
+8. Click **Save contact point**
+
+### 3. Import Alert Rules
+
+**Option A: Manual Import (Recommended)**
+
+1. In Grafana, navigate to **Alerting** → **Alert rules**
+2. Click **New alert rule**
+3. For each alert in `grafana-alert-rules.yaml`, create manually:
+   - Copy the PromQL query from `expr` field
+   - Set the threshold from `evaluator.params`
+   - Set evaluation time from `for` field
+   - Add annotations for summary/description
+   - Select contact point: `Pedro Discord Alerts`
+
+**Option B: Provisioning (Advanced)**
+
+If you're running Grafana in Docker or Kubernetes:
+
+1. Copy `grafana-alert-rules.yaml` to your Grafana provisioning directory:
+   ```bash
+   cp deployment/grafana-alert-rules.yaml /etc/grafana/provisioning/alerting/
+   ```
+
+2. Update the `datasourceUid` in the YAML file to match your Prometheus datasource UID:
+   - In Grafana, go to **Connections** → **Data sources** → **Prometheus**
+   - Copy the UID from the URL (e.g., `P1809F7CD0C75ACF3`)
+   - Replace all instances of `prometheus` in the YAML with your actual UID
+
+3. Restart Grafana
+
+4. Configure the contact point for the alert group:
+   - Navigate to **Alerting** → **Notification policies**
+   - Click **+ New nested policy**
+   - Match label: `severity = critical|warning|info`
+   - Contact point: `Pedro Discord Alerts`
+   - Save policy
+
+### 4. Verify Alerts
+
+1. Navigate to **Alerting** → **Alert rules**
+2. You should see folders:
+   - **pedro_critical_alerts** (4 rules)
+   - **pedro_warning_alerts** (6 rules)
+   - **pedro_info_alerts** (2 rules)
+3. Check that all alerts show "Normal" or "Pending" state
+4. Verify contact point is assigned
+
+### 5. Test an Alert
+
+Trigger a test alert to verify Discord notifications work:
+
+1. Find an alert that's easy to trigger (e.g., "High Memory Usage")
+2. Temporarily lower the threshold to trigger it
+3. Wait for evaluation period
+4. Check Discord channel for alert notification
+5. Restore original threshold
+
+## Alert Summary
+
+### 🚨 Critical Alerts (1m check interval)
+- **Twitch Bot Offline** - No active Twitch connection
+- **Discord Bot High Error Rate** - >20% commands failing
+- **vLLM Service Down** - vLLM not responding
+- **High LLM Failure Rate** - >15% LLM calls failing
+
+### ⚠️ Warning Alerts (2m check interval)
+- **vLLM High TTFT** - p95 time-to-first-token >1s
+- **vLLM High E2E Latency** - p95 end-to-end >3s
+- **vLLM KV Cache High** - Cache usage >85%
+- **vLLM Queue Backup** - >10 requests waiting
+- **High Empty Response Rate** - >25% empty LLM responses
+- **Web Search Failures** - >30% searches failing
+- **Discord Commands Slow** - p95 latency >5s
+
+### 📊 Info Alerts (5m check interval)
+- **High Memory Usage** - Go bots >100MB heap
+- **vLLM High Memory** - vLLM >2GB resident memory
+
+## Customization
+
+### Adjust Thresholds
+
+Edit thresholds in the YAML file by changing the `params` values:
+
+```yaml
+evaluator:
+  params:
+    - 0.2  # Change this value (20% in this example)
+  type: gt  # gt = greater than, lt = less than
+```
+
+### Add Custom Alerts
+
+To add your own alert:
+
+1. Copy an existing alert block from the YAML
+2. Generate a new UID: `pedro_<descriptive_name>`
+3. Modify the PromQL query in the `expr` field
+4. Update thresholds, annotations, and labels
+5. Re-import the file
+
+### Silence Alerts
+
+To temporarily disable an alert:
+
+1. Navigate to **Alerting** → **Silences**
+2. Click **Add silence**
+3. Add matcher: `alertname = <alert_title>`
+4. Set duration and comment
+5. Click **Submit**
+
+## Troubleshooting
+
+### Alerts Not Firing
+
+- Check Prometheus is scraping metrics correctly
+- Verify datasource UID matches in alert rules
+- Check alert evaluation logs in **Alerting** → **Alert rules** → (click alert) → **State history**
+
+### Discord Notifications Not Sending
+
+- Test the contact point: **Alerting** → **Contact points** → **Test**
+- Verify webhook URL is correct
+- Check Grafana logs for Discord API errors
+- Ensure notification policy is routing alerts to your contact point
+
+### Metrics Not Found
+
+If you see "no data" errors:
+- Verify the service is exposing metrics at the correct port
+- Check Prometheus is configured to scrape the service
+- Confirm metric names match between the alert rules and actual metrics
+
+## Dashboard Files
+
+- `grafana-vllm-dashboard.json` - vLLM performance metrics
+- `grafana-twitch-dashboard.json` - Twitch bot metrics
+- `grafana-discord-dashboard.json` - Discord bot metrics with command-level details
+
+Import these dashboards to visualize the same metrics used in alerts.

--- a/config/grafana/README.md
+++ b/config/grafana/README.md
@@ -1,0 +1,165 @@
+# Grafana Configuration
+
+This directory contains Grafana dashboards and alert rules for monitoring Pedro bot services.
+
+## Contents
+
+### Dashboards
+
+- **`grafana-vllm-dashboard.json`** - vLLM Performance Metrics
+  - Request latency (TTFT, E2E)
+  - Token throughput
+  - KV cache usage
+  - Memory usage
+  - Request finish reason distribution
+
+- **`grafana-twitch-dashboard.json`** - Twitch Bot Metrics
+  - Connection status
+  - Message rate (sent/received)
+  - LLM response metrics (successful/failed/empty)
+  - Web search success rate
+
+- **`grafana-discord-dashboard.json`** - Discord Bot Metrics
+  - Command metrics by type (`/ask_pedro`, `/stump_pedro`, `/help_pedro`)
+  - Command latency tracking
+  - Error rates by command
+  - 20 Questions game statistics (started/won/lost)
+  - Pedro win rate gauge
+
+### Alert Rules
+
+- **`grafana-alert-rules.yaml`** - Pre-configured alert rules
+  - **Critical alerts**: Service outages, high error rates
+  - **Warning alerts**: Performance degradation, high latency
+  - **Info alerts**: Memory usage, low activity
+
+### Documentation
+
+- **`ALERTS-README.md`** - Complete guide for setting up alerts with Discord webhooks
+
+## Quick Import
+
+### Import Dashboards
+
+1. In Grafana, go to **Dashboards** → **Import**
+2. Click **Upload JSON file**
+3. Select one of the dashboard JSON files
+4. Choose your Prometheus datasource
+5. Click **Import**
+
+### Setup Alerts
+
+See [`ALERTS-README.md`](./ALERTS-README.md) for complete setup instructions.
+
+## Directory Structure
+
+```
+config/grafana/
+├── README.md                          # This file
+├── ALERTS-README.md                   # Alert setup guide
+├── grafana-vllm-dashboard.json        # vLLM dashboard
+├── grafana-twitch-dashboard.json      # Twitch bot dashboard
+├── grafana-discord-dashboard.json     # Discord bot dashboard
+└── grafana-alert-rules.yaml           # Alert rules configuration
+```
+
+## Prerequisites
+
+- Grafana 10.0+
+- Prometheus datasource configured
+- Pedro services exposing metrics:
+  - Twitch bot: http://localhost:6061/metrics
+  - Discord bot: http://localhost:6060/metrics
+  - vLLM: http://localhost:8000/metrics (or your vLLM endpoint)
+
+## Prometheus Configuration
+
+Ensure your `prometheus.yml` includes these scrape targets:
+
+```yaml
+scrape_configs:
+  - job_name: 'pedro-twitch'
+    static_configs:
+      - targets: ['localhost:6061']
+
+  - job_name: 'pedro-discord'
+    static_configs:
+      - targets: ['localhost:6060']
+
+  - job_name: 'vllm'
+    static_configs:
+      - targets: ['localhost:8000']  # Adjust to your vLLM endpoint
+```
+
+## Metrics Exposed
+
+### Twitch Bot (expvar + Go runtime)
+- `twitch_connection_count` - Connection status
+- `twitch_message_recieved_count` - Messages received
+- `twitch_message_sent_count` - Messages sent
+- `successful_llm_gen_count` - Successful LLM generations
+- `failed_llm_gen_count` - Failed LLM generations
+- `empty_llm_response_count` - Empty LLM responses
+- `web_search_success_count` - Successful web searches
+- `web_search_fail_count` - Failed web searches
+- Go runtime metrics (memory, GC, goroutines, etc.)
+
+### Discord Bot (Prometheus + expvar + Go runtime)
+- `discord_command_total{command="<name>"}` - Commands executed (with labels)
+- `discord_command_errors{command="<name>"}` - Command errors (with labels)
+- `discord_command_duration_seconds` - Command latency histogram (with labels)
+- `discord_stump_pedro_games_total{status="<status>"}` - 20Q game stats
+- `discord_message_recieved` - Messages received (legacy)
+- `discord_message_sent` - Messages sent (legacy)
+- Go runtime metrics
+
+### vLLM (Prometheus)
+- `vllm:request_success_total{finished_reason="<reason>",model_name="<model>"}` - Request outcomes
+- `vllm:time_to_first_token_seconds` - TTFT histogram
+- `vllm:e2e_request_latency_seconds` - E2E latency histogram
+- `vllm:prompt_tokens_total` - Prompt tokens processed
+- `vllm:generation_tokens_total` - Generation tokens processed
+- `vllm:kv_cache_usage_perc` - KV cache utilization
+- `vllm:num_requests_running` - Active requests
+- `vllm:num_requests_waiting` - Queued requests
+- Process metrics (memory, CPU)
+
+## Dashboard Features
+
+### Command-Level Monitoring (Discord)
+The Discord dashboard uses Prometheus labels to track metrics per command type:
+- View usage patterns by command
+- Compare latency across different commands
+- Identify which commands are failing
+
+Example queries:
+```promql
+# Command usage over time
+rate(discord_command_total{command="ask_pedro"}[5m])
+
+# Error rate by command
+rate(discord_command_errors[5m]) / rate(discord_command_total[5m])
+
+# p95 latency by command
+histogram_quantile(0.95, sum(rate(discord_command_duration_seconds_bucket[5m])) by (command, le))
+```
+
+### vLLM Model Tracking
+All vLLM metrics include the `model_name` label, allowing you to:
+- Monitor multiple models simultaneously
+- Compare performance across different models
+- Track model-specific issues
+
+## Updating Dashboards
+
+After making changes to dashboards in Grafana:
+
+1. Export the updated dashboard JSON
+2. Replace the corresponding file in this directory
+3. Commit to git for version control
+
+## Related Documentation
+
+- [Main README](../../README.md#setting-up-grafana-alerts-with-discord) - Grafana setup overview
+- [Deployment Scripts](../../deployment/README.md) - Deployment automation
+- [KeepAlive Service](../../keepalive/README.md) - Health monitoring with Discord alerts

--- a/config/grafana/provisioning/alerting/grafana-alert-rules.yaml
+++ b/config/grafana/provisioning/alerting/grafana-alert-rules.yaml
@@ -1,0 +1,706 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: pedro_critical_alerts
+    folder: Pedro Bot Alerts
+    interval: 1m
+    rules:
+      - uid: pedro_twitch_offline
+        title: Twitch Bot Offline
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: twitch_connection_count
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: Twitch bot connection is down
+          description: The Twitch bot has no active connection. Bot is offline.
+        labels:
+          severity: critical
+          service: twitch
+
+      - uid: pedro_discord_high_errors
+        title: Discord Bot High Error Rate
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: sum(rate(discord_command_errors[5m])) / (sum(rate(discord_command_total[5m])) + 0.001)
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.2
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 3m
+        annotations:
+          summary: Discord command error rate is {{ printf "%.1f" $values.A.Value }}%
+          description: More than 20% of Discord commands are failing. Check Discord bot logs.
+        labels:
+          severity: critical
+          service: discord
+
+      - uid: pedro_vllm_offline
+        title: vLLM Service Down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: up{job=~"vllm.*|llm.*"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: vLLM service is DOWN
+          description: The vLLM service is not responding. All LLM functionality is unavailable.
+        labels:
+          severity: critical
+          service: vllm
+
+      - uid: pedro_llm_high_failures
+        title: High LLM Failure Rate
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(failed_llm_gen_count[5m]) / (rate(successful_llm_gen_count[5m]) + rate(failed_llm_gen_count[5m]) + 0.001)
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.15
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: LLM failure rate is {{ printf "%.1f" (mul $values.A.Value 100) }}%
+          description: More than 15% of LLM calls are failing. Check vLLM service and logs.
+        labels:
+          severity: critical
+          service: llm
+
+  - orgId: 1
+    name: pedro_warning_alerts
+    folder: Pedro Bot Alerts
+    interval: 2m
+    rules:
+      - uid: pedro_vllm_high_ttft
+        title: vLLM High Time to First Token
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.95, sum(rate(vllm:time_to_first_token_seconds_bucket[5m])) by (le, model_name))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1.0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: vLLM p95 TTFT is {{ printf "%.2f" $values.A.Value }}s
+          description: Time to first token latency is high. Users experiencing slow responses.
+        labels:
+          severity: warning
+          service: vllm
+
+      - uid: pedro_vllm_high_e2e_latency
+        title: vLLM High End-to-End Latency
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.95, sum(rate(vllm:e2e_request_latency_seconds_bucket[5m])) by (le, model_name))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 3.0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: vLLM p95 E2E latency is {{ printf "%.2f" $values.A.Value }}s
+          description: End-to-end request latency is above 3 seconds. Check vLLM performance.
+        labels:
+          severity: warning
+          service: vllm
+
+      - uid: pedro_vllm_cache_high
+        title: vLLM KV Cache High Usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: vllm:kv_cache_usage_perc
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.85
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 3m
+        annotations:
+          summary: vLLM KV cache usage is {{ printf "%.1f" (mul $values.A.Value 100) }}%
+          description: KV cache is above 85% capacity. May impact performance soon.
+        labels:
+          severity: warning
+          service: vllm
+
+      - uid: pedro_vllm_queue_backup
+        title: vLLM Request Queue Backing Up
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: vllm:num_requests_waiting
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 10
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 2m
+        annotations:
+          summary: vLLM has {{ $values.A.Value }} requests waiting
+          description: Request queue depth is high. vLLM may be overloaded.
+        labels:
+          severity: warning
+          service: vllm
+
+      - uid: pedro_empty_responses
+        title: High Empty LLM Response Rate
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(empty_llm_response_count[5m]) / (rate(successful_llm_gen_count[5m]) + 0.001)
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.25
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Empty response rate is {{ printf "%.1f" (mul $values.A.Value 100) }}%
+          description: More than 25% of LLM responses are empty. Check model configuration.
+        labels:
+          severity: warning
+          service: llm
+
+      - uid: pedro_web_search_failures
+        title: Web Search High Failure Rate
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(web_search_fail_count[5m]) / (rate(web_search_success_count[5m]) + rate(web_search_fail_count[5m]) + 0.001)
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.3
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Web search failure rate is {{ printf "%.1f" (mul $values.A.Value 100) }}%
+          description: More than 30% of web searches are failing. Check DuckDuckGo integration.
+        labels:
+          severity: warning
+          service: web_search
+
+      - uid: pedro_discord_slow_commands
+        title: Discord Commands Slow
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.95, sum(rate(discord_command_duration_seconds_bucket[5m])) by (command, le))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 5.0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 3m
+        annotations:
+          summary: Discord command p95 latency is {{ printf "%.2f" $values.A.Value }}s
+          description: Discord commands are taking longer than 5 seconds. Check performance.
+        labels:
+          severity: warning
+          service: discord
+
+  - orgId: 1
+    name: pedro_info_alerts
+    folder: Pedro Bot Alerts
+    interval: 5m
+    rules:
+      - uid: pedro_memory_high
+        title: High Memory Usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: go_memstats_heap_alloc_bytes
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 100000000
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: Bot memory usage is {{ humanize1024 $values.A.Value }}
+          description: Heap allocation is above 100MB. Monitor for memory leaks.
+        labels:
+          severity: info
+          service: bot
+
+      - uid: pedro_vllm_memory_high
+        title: vLLM High Memory Usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: process_resident_memory_bytes{job=~"vllm.*|llm.*"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 2000000000
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: vLLM memory usage is {{ humanize1024 $values.A.Value }}
+          description: vLLM memory is above 2GB. Monitor for issues.
+        labels:
+          severity: info
+          service: vllm

--- a/config/grafana/provisioning/dashboards/dashboards.yml
+++ b/config/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'Pedro Dashboards'
+    orgId: 1
+    folder: 'Pedro Bot'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/config/grafana/provisioning/dashboards/json/grafana-discord-dashboard.json
+++ b/config/grafana/provisioning/dashboards/json/grafana-discord-dashboard.json
@@ -1,0 +1,1063 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_message_recieved",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Messages Received",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_message_sent",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Messages Sent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(discord_command_total)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Commands Executed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "go_memstats_alloc_bytes",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_command_total{command=\"ask_pedro\"}[5m])",
+          "legendFormat": "/ask_pedro",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_command_total{command=\"stump_pedro\"}[5m])",
+          "legendFormat": "/stump_pedro",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_command_total{command=\"help_pedro\"}[5m])",
+          "legendFormat": "/help_pedro",
+          "refId": "C"
+        }
+      ],
+      "title": "Command Rate by Type (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": ["value"]
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_command_total{command=\"ask_pedro\"}",
+          "legendFormat": "/ask_pedro",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_command_total{command=\"stump_pedro\"}",
+          "legendFormat": "/stump_pedro",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_command_total{command=\"help_pedro\"}",
+          "legendFormat": "/help_pedro",
+          "refId": "C"
+        }
+      ],
+      "title": "Command Distribution",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(discord_command_duration_seconds_bucket[5m])) by (command, le))",
+          "legendFormat": "p50 - {{command}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(discord_command_duration_seconds_bucket[5m])) by (command, le))",
+          "legendFormat": "p95 - {{command}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(discord_command_duration_seconds_bucket[5m])) by (command, le))",
+          "legendFormat": "p99 - {{command}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Command Latency by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Error.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_command_errors[5m])",
+          "legendFormat": "Error - {{command}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Command Errors by Type (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_stump_pedro_games_total{status=\"started\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "20Q Games Started",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_stump_pedro_games_total{status=\"won\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "20Q Games Won (Pedro)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "discord_stump_pedro_games_total{status=\"lost\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "20Q Games Lost (Pedro)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(discord_stump_pedro_games_total{status=\"won\"} / (discord_stump_pedro_games_total{status=\"won\"} + discord_stump_pedro_games_total{status=\"lost\"})) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "20Q Pedro Win Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Started"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Won"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lost"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_stump_pedro_games_total{status=\"started\"}[5m])",
+          "legendFormat": "Started",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_stump_pedro_games_total{status=\"won\"}[5m])",
+          "legendFormat": "Won",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(discord_stump_pedro_games_total{status=\"lost\"}[5m])",
+          "legendFormat": "Lost",
+          "refId": "C"
+        }
+      ],
+      "title": "20 Questions Game Rate (per second)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["pedro", "discord", "bot"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Pedro Discord Bot Metrics",
+  "uid": "pedro-discord-bot-metrics",
+  "version": 0,
+  "weekStart": ""
+}

--- a/config/grafana/provisioning/dashboards/json/grafana-twitch-dashboard.json
+++ b/config/grafana/provisioning/dashboards/json/grafana-twitch-dashboard.json
@@ -30,6 +30,369 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "twitch_connection_count",
+          "refId": "A"
+        }
+      ],
+      "title": "Twitch Connection Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "twitch_message_recieved_count",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Messages Received",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "twitch_message_sent_count",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Messages Sent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "go_memstats_alloc_bytes",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Received"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sent"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(twitch_message_recieved_count[5m])",
+          "legendFormat": "Received",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(twitch_message_sent_count[5m])",
+          "legendFormat": "Sent",
+          "refId": "B"
+        }
+      ],
+      "title": "Message Rate (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -125,13 +488,13 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 0
+        "x": 12,
+        "y": 6
       },
-      "id": 1,
+      "id": 6,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": ["lastNotNull", "sum"],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -147,7 +510,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(successfull_llm_gen[5m])",
+          "expr": "rate(successful_llm_gen_count[5m])",
           "legendFormat": "Successful",
           "refId": "A"
         },
@@ -156,7 +519,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(failed_llm_gen[5m])",
+          "expr": "rate(failed_llm_gen_count[5m])",
           "legendFormat": "Failed",
           "refId": "B"
         },
@@ -165,13 +528,86 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(empty_llm_response[5m])",
+          "expr": "rate(empty_llm_response_count[5m])",
           "legendFormat": "Empty",
           "refId": "C"
         }
       ],
       "title": "LLM Response Rate (per second)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": ["value"]
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "successful_llm_gen_count",
+          "legendFormat": "Successful",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "failed_llm_gen_count",
+          "legendFormat": "Failed",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "empty_llm_response_count",
+          "legendFormat": "Empty",
+          "refId": "C"
+        }
+      ],
+      "title": "LLM Response Distribution",
+      "type": "piechart"
     },
     {
       "datasource": {
@@ -209,11 +645,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 0
+        "w": 8,
+        "x": 8,
+        "y": 14
       },
-      "id": 2,
+      "id": 8,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -231,461 +667,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "(successfull_llm_gen / (successfull_llm_gen + failed_llm_gen + empty_llm_response)) * 100",
+          "expr": "(successful_llm_gen_count / (successful_llm_gen_count + failed_llm_gen_count + empty_llm_response_count)) * 100",
           "refId": "A"
         }
       ],
       "title": "LLM Success Rate",
       "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true,
-          "values": ["value"]
-        },
-        "pieType": "pie",
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "successfull_llm_gen",
-          "legendFormat": "Successful",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "failed_llm_gen",
-          "legendFormat": "Failed",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "empty_llm_response",
-          "legendFormat": "Empty",
-          "refId": "C"
-        }
-      ],
-      "title": "LLM Response Distribution",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Received"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(twitch_message_recieved_count[5m])",
-          "legendFormat": "Received",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(twitch_message_sent_count[5m])",
-          "legendFormat": "Sent",
-          "refId": "B"
-        }
-      ],
-      "title": "Twitch Message Rate (per second)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Received"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(discord_message_recieved[5m])",
-          "legendFormat": "Received",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(discord_message_sent[5m])",
-          "legendFormat": "Sent",
-          "refId": "B"
-        }
-      ],
-      "title": "Discord Message Rate (per second)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 16
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "twitch_connection_count",
-          "refId": "A"
-        }
-      ],
-      "title": "Twitch Connections",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 16
-      },
-      "id": 7,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "successfull_llm_gen",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Successful LLM Responses",
-      "type": "stat"
     },
     {
       "datasource": {
@@ -717,11 +704,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 16
+        "w": 8,
+        "x": 16,
+        "y": 14
       },
-      "id": 8,
+      "id": 9,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -741,7 +728,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "failed_llm_gen",
+          "expr": "failed_llm_gen_count",
           "refId": "A"
         }
       ],
@@ -778,11 +765,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 16
+        "w": 8,
+        "x": 16,
+        "y": 18
       },
-      "id": 9,
+      "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -802,7 +789,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "empty_llm_response",
+          "expr": "empty_llm_response_count",
           "refId": "A"
         }
       ],
@@ -898,12 +885,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 22
       },
-      "id": 10,
+      "id": 11,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": ["lastNotNull", "sum"],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -972,11 +959,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 12,
         "x": 12,
-        "y": 20
+        "y": 22
       },
-      "id": 11,
+      "id": 12,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -1000,108 +987,12 @@
       ],
       "title": "Web Search Success Rate",
       "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 20
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "go_memstats_alloc_bytes{job=\"discord\"}",
-          "legendFormat": "Discord Bot",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "go_memstats_alloc_bytes{job=\"twitch\"}",
-          "legendFormat": "Twitch Bot",
-          "refId": "B"
-        }
-      ],
-      "title": "Memory Usage",
-      "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["pedro", "twitch", "discord", "llm"],
+  "tags": ["pedro", "twitch", "bot"],
   "templating": {
     "list": [
       {
@@ -1130,8 +1021,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Pedro Bot Metrics",
-  "uid": "pedro-bot-metrics",
+  "title": "Pedro Twitch Bot Metrics",
+  "uid": "pedro-twitch-bot-metrics",
   "version": 0,
   "weekStart": ""
 }

--- a/config/grafana/provisioning/dashboards/json/grafana-vllm-dashboard.json
+++ b/config/grafana/provisioning/dashboards/json/grafana-vllm-dashboard.json
@@ -1,0 +1,891 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:request_success_total{finished_reason=\"stop\",model_name=~\".*\"}",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Successful Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:num_requests_running",
+          "refId": "A"
+        }
+      ],
+      "title": "Running Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:num_requests_waiting",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:kv_cache_usage_perc",
+          "refId": "A"
+        }
+      ],
+      "title": "KV Cache Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(vllm:time_to_first_token_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p50 TTFT - {{model_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(vllm:time_to_first_token_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p95 TTFT - {{model_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(vllm:time_to_first_token_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p99 TTFT - {{model_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Time to First Token (TTFT)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(vllm:e2e_request_latency_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p50 E2E - {{model_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(vllm:e2e_request_latency_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p95 E2E - {{model_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(vllm:e2e_request_latency_seconds_bucket[5m])) by (le, model_name))",
+          "legendFormat": "p99 E2E - {{model_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "End-to-End Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "tokens/s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Prompt Tokens"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Generation Tokens"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(vllm:prompt_tokens_total[5m])",
+          "legendFormat": "Prompt Tokens",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(vllm:generation_tokens_total[5m])",
+          "legendFormat": "Generation Tokens",
+          "refId": "B"
+        }
+      ],
+      "title": "Token Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "process_resident_memory_bytes{job=~\"vllm.*|llm.*\"}",
+          "legendFormat": "vLLM Memory",
+          "refId": "A"
+        }
+      ],
+      "title": "vLLM Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": ["value"]
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:request_success_total{finished_reason=\"stop\"}",
+          "legendFormat": "Stop (Success)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:request_success_total{finished_reason=\"length\"}",
+          "legendFormat": "Length (Max tokens)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "vllm:request_success_total{finished_reason=\"abort\"}",
+          "legendFormat": "Abort",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Finish Reason Distribution",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(vllm:request_success_total[5m])",
+          "legendFormat": "Requests/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["pedro", "vllm", "llm", "performance"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "vLLM Performance Metrics",
+  "uid": "vllm-performance-metrics",
+  "version": 0,
+  "weekStart": ""
+}

--- a/config/grafana/provisioning/datasources/prometheus.yml
+++ b/config/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://100.125.196.1:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -239,9 +239,9 @@ The bots expose these metrics:
 - `twitch_message_sent_count` - Messages sent to Twitch  
 - `discord_message_recieved` - Messages received from Discord
 - `discord_message_sent` - Messages sent to Discord
-- `empty_llm_response` - Empty responses from LLM
-- `successfull_llm_gen` - Successful LLM generations
-- `failed_llm_gen` - Failed LLM generations
+- `empty_llm_response_count` - Empty responses from LLM
+- `successful_llm_gen_count` - Successful LLM generations
+- `failed_llm_gen_count` - Failed LLM generations
 
 ## Troubleshooting
 

--- a/discord/help.go
+++ b/discord/help.go
@@ -1,11 +1,21 @@
 package discord
 
 import (
+	"time"
+
 	"github.com/Soypete/twitch-llm-bot/metrics"
 	"github.com/bwmarrin/discordgo"
 )
 
 func (d Client) help(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Track command metrics
+	start := time.Now()
+	metrics.DiscordCommandTotal.WithLabelValues("help_pedro").Inc()
+	defer func() {
+		duration := time.Since(start).Seconds()
+		metrics.DiscordCommandDuration.WithLabelValues("help_pedro").Observe(duration)
+	}()
+
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -14,6 +24,7 @@ func (d Client) help(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		d.logger.Error("error responding to help command", "error", err.Error())
+		metrics.DiscordCommandErrors.WithLabelValues("help_pedro").Inc()
 		return
 	}
 	d.logger.Debug("help command handled successfully")

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	EmptyLLMResponse           = expvar.NewInt("empty_llm_response")
-	SuccessfulLLMGen           = expvar.NewInt("succesful_llm_gen")
-	FailedLLMGen               = expvar.NewInt("failed_llm_gen")
+	// Expvar metrics (legacy)
+	EmptyLLMResponseCount      = expvar.NewInt("empty_llm_response_count")
+	SuccessfulLLMGenCount      = expvar.NewInt("successful_llm_gen_count")
+	FailedLLMGenCount          = expvar.NewInt("failed_llm_gen_count")
 	TwitchConnectionCount      = expvar.NewInt("twitch_connection_count")
 	TwitchMessageRecievedCount = expvar.NewInt("twitch_message_recieved_count")
 	TwitchMessageSentCount     = expvar.NewInt("twitch_message_sent_count")
@@ -22,6 +23,40 @@ var (
 	DiscordMessageSent         = expvar.NewInt("discord_message_sent")
 	WebSearchSuccessCount      = expvar.NewInt("web_search_success_count")
 	WebSearchFailCount         = expvar.NewInt("web_search_fail_count")
+
+	// Prometheus metrics with labels
+	DiscordCommandTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "discord_command_total",
+			Help: "Total number of Discord commands invoked by command type",
+		},
+		[]string{"command"},
+	)
+
+	DiscordCommandErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "discord_command_errors",
+			Help: "Total number of Discord command errors by command type",
+		},
+		[]string{"command"},
+	)
+
+	DiscordCommandDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "discord_command_duration_seconds",
+			Help:    "Duration of Discord command execution in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"command"},
+	)
+
+	DiscordStumpPedroGames = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "discord_stump_pedro_games_total",
+			Help: "Total number of 20 questions games by status (started, won, lost)",
+		},
+		[]string{"status"},
+	)
 )
 
 type Server struct {
@@ -38,17 +73,20 @@ func SetupServer() *Server {
 	}
 
 	// setup expvar cache
-	EmptyLLMResponse.Set(0)
-	SuccessfulLLMGen.Set(0)
-	FailedLLMGen.Set(0)
+	EmptyLLMResponseCount.Set(0)
+	SuccessfulLLMGenCount.Set(0)
+	FailedLLMGenCount.Set(0)
 	TwitchConnectionCount.Set(0)
 	TwitchMessageRecievedCount.Set(0)
 	TwitchMessageSentCount.Set(0)
+	DiscordMessageRecieved.Set(0)
+	DiscordMessageSent.Set(0)
 	WebSearchSuccessCount.Set(0)
 	WebSearchFailCount.Set(0)
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(collectors.NewBuildInfoCollector(),
+	reg.MustRegister(
+		collectors.NewBuildInfoCollector(),
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewExpvarCollector(
@@ -56,13 +94,21 @@ func SetupServer() *Server {
 				"twitch_connection_count":       prometheus.NewDesc("twitch_connection_count", "number of times twitch connection was established", nil, nil),
 				"twitch_message_recieved_count": prometheus.NewDesc("twitch_message_recieved_count", "number of times twitch recieved a message", nil, nil),
 				"twitch_message_sent_count":     prometheus.NewDesc("twitch_message_sent_count", "number of times twitch sent a message", nil, nil),
-				"empty_llm_response":            prometheus.NewDesc("empty_llm_response", "number of times llm responded with and empty string ", nil, nil),
-				"successfull_llm_gen":           prometheus.NewDesc("successfull_llm_gen", "number of times llm generated a valid response", nil, nil),
-				"failed_llm_gen":                prometheus.NewDesc("failed_llm_gen", "number of times errors occured in llm generation", nil, nil),
+				"discord_message_recieved":      prometheus.NewDesc("discord_message_recieved", "number of times discord received a message", nil, nil),
+				"discord_message_sent":          prometheus.NewDesc("discord_message_sent", "number of times discord sent a message", nil, nil),
+				"empty_llm_response_count":      prometheus.NewDesc("empty_llm_response_count", "number of times llm responded with and empty string ", nil, nil),
+				"successful_llm_gen_count":      prometheus.NewDesc("successful_llm_gen_count", "number of times llm generated a valid response", nil, nil),
+				"failed_llm_gen_count":          prometheus.NewDesc("failed_llm_gen_count", "number of times errors occured in llm generation", nil, nil),
 				"web_search_success_count":      prometheus.NewDesc("web_search_success_count", "number of successful web searches", nil, nil),
 				"web_search_fail_count":         prometheus.NewDesc("web_search_fail_count", "number of failed web searches", nil, nil),
 			},
-		))
+		),
+		// Register Discord command metrics with labels
+		DiscordCommandTotal,
+		DiscordCommandErrors,
+		DiscordCommandDuration,
+		DiscordStumpPedroGames,
+	)
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 	http.HandleFunc("/healthz", healthzHandler)


### PR DESCRIPTION
 Add comprehensive Grafana monitoring setup with auto-provisioning:
    - Discord bot dashboard with command metrics and 20 questions game tracking
    - Twitch bot dashboard with LLM metrics and message tracking
    - vLLM dashboard with performance and resource metrics
    - Automated provisioning via docker-compose volume mounts
    - Alert rules for critical failures, high error rates, and performance issues

    Rename LLM metrics to follow Prometheus naming conventions:
    - SuccessfulLLMGen → SuccessfulLLMGenCount (successful_llm_gen_count)
    - FailedLLMGen → FailedLLMGenCount (failed_llm_gen_count)
    - EmptyLLMResponse → EmptyLLMResponseCount (empty_llm_response_count)

    Also fixed typo: "successfull" → "successful" throughout codebase.

    Updated Discord command handlers to track metrics with labels for better observability.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>