### PR TITLE
feat: add Twitch auth token health monitoring

### DIFF
--- a/cli/keepalive/main.go
+++ b/cli/keepalive/main.go
@@ -71,9 +71,12 @@ func main() {
 	}
 
 	// Add Twitch bot if URL is provided
+	// Extract base URL and add auth health endpoint
+	twitchBotAuthURL := getEnv("TWITCH_BOT_AUTH_URL", "http://localhost:6061/healthz/auth")
 	services = append(services, keepalive.ServiceConfig{
-		Name:      "Twitch Bot",
-		HealthURL: twitchBotURL,
+		Name:         "Twitch Bot",
+		HealthURL:    twitchBotURL,
+		AuthHealthURL: twitchBotAuthURL,
 	})
 
 	// Add VLLM/llama.cpp if LLAMA_CPP_PATH is set

--- a/cli/twitch/twitch.go
+++ b/cli/twitch/twitch.go
@@ -61,6 +61,11 @@ func main() {
 		logger.Error("failed to setup twitch IRC", "error", err.Error())
 		stop <- os.Interrupt
 	}
+
+	// Register auth health endpoint
+	server.RegisterAuthHealthHandler(irc.AuthHealthHandler())
+	logger.Debug("auth health endpoint registered at /healthz/auth")
+
 	logger.Info("starting twitch IRC connection")
 	// long running function
 	err = irc.ConnectIRC(ctx, wg)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -115,6 +115,11 @@ func SetupServer() *Server {
 	return &Server{server}
 }
 
+// RegisterAuthHealthHandler registers the auth health check endpoint
+func (s *Server) RegisterAuthHealthHandler(handler http.HandlerFunc) {
+	http.HandleFunc("/healthz/auth", handler)
+}
+
 // healthzHandler returns a simple health check response
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)

--- a/twitch/auth_health.go
+++ b/twitch/auth_health.go
@@ -1,0 +1,55 @@
+package twitchirc
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// AuthHealthResponse represents the JSON response for the auth health check endpoint
+type AuthHealthResponse struct {
+	HasToken         bool      `json:"has_token"`
+	LastRefreshTime  time.Time `json:"last_refresh_time"`
+	ExpirationTime   time.Time `json:"expiration_time"`
+	IsExpired        bool      `json:"is_expired"`
+	HoursUntilExpiry float64   `json:"hours_until_expiry"`
+}
+
+const tokenExpiryDuration = 12 * time.Hour
+
+// GetAuthHealth returns the current auth token health status
+func (irc *IRC) GetAuthHealth() AuthHealthResponse {
+	hasToken := irc.tok != nil && irc.tok.AccessToken != ""
+	expirationTime := irc.tokenRefreshTime.Add(tokenExpiryDuration)
+	hoursUntilExpiry := time.Until(expirationTime).Hours()
+	isExpired := time.Now().After(expirationTime)
+
+	return AuthHealthResponse{
+		HasToken:         hasToken,
+		LastRefreshTime:  irc.tokenRefreshTime,
+		ExpirationTime:   expirationTime,
+		IsExpired:        isExpired,
+		HoursUntilExpiry: hoursUntilExpiry,
+	}
+}
+
+// AuthHealthHandler returns an HTTP handler for the auth health check endpoint
+func (irc *IRC) AuthHealthHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		health := irc.GetAuthHealth()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(health); err != nil {
+			irc.logger.Error("failed to encode auth health response", "error", err.Error())
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/twitch/auth_health_test.go
+++ b/twitch/auth_health_test.go
@@ -1,0 +1,257 @@
+package twitchirc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Soypete/twitch-llm-bot/logging"
+	"golang.org/x/oauth2"
+)
+
+func TestGetAuthHealth(t *testing.T) {
+	tests := []struct {
+		name             string
+		token            *oauth2.Token
+		tokenRefreshTime time.Time
+		wantHasToken     bool
+		wantIsExpired    bool
+	}{
+		{
+			name: "valid token not expired",
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+			},
+			tokenRefreshTime: time.Now().Add(-6 * time.Hour), // 6 hours ago
+			wantHasToken:     true,
+			wantIsExpired:    false,
+		},
+		{
+			name: "token expired",
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+			},
+			tokenRefreshTime: time.Now().Add(-13 * time.Hour), // 13 hours ago
+			wantHasToken:     true,
+			wantIsExpired:    true,
+		},
+		{
+			name:             "no token",
+			token:            nil,
+			tokenRefreshTime: time.Time{},
+			wantHasToken:     false,
+			wantIsExpired:    true,
+		},
+		{
+			name: "empty token",
+			token: &oauth2.Token{
+				AccessToken: "",
+			},
+			tokenRefreshTime: time.Now(),
+			wantHasToken:     false,
+			wantIsExpired:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := logging.NewLogger(logging.LogLevel("error"), nil)
+			irc := &IRC{
+				tok:              tt.token,
+				tokenRefreshTime: tt.tokenRefreshTime,
+				logger:           logger,
+			}
+
+			health := irc.GetAuthHealth()
+
+			if health.HasToken != tt.wantHasToken {
+				t.Errorf("HasToken = %v, want %v", health.HasToken, tt.wantHasToken)
+			}
+
+			if health.IsExpired != tt.wantIsExpired {
+				t.Errorf("IsExpired = %v, want %v", health.IsExpired, tt.wantIsExpired)
+			}
+
+			// Verify expiration time is correctly calculated
+			expectedExpiry := tt.tokenRefreshTime.Add(tokenExpiryDuration)
+			if !health.ExpirationTime.Equal(expectedExpiry) {
+				t.Errorf("ExpirationTime = %v, want %v", health.ExpirationTime, expectedExpiry)
+			}
+		})
+	}
+}
+
+func TestAuthHealthHandler(t *testing.T) {
+	tests := []struct {
+		name               string
+		method             string
+		token              *oauth2.Token
+		tokenRefreshTime   time.Time
+		wantStatus         int
+		wantHasToken       bool
+		wantIsExpired      bool
+		checkHoursUntilExp bool
+	}{
+		{
+			name:   "GET request with valid token",
+			method: http.MethodGet,
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+			},
+			tokenRefreshTime:   time.Now().Add(-2 * time.Hour),
+			wantStatus:         http.StatusOK,
+			wantHasToken:       true,
+			wantIsExpired:      false,
+			checkHoursUntilExp: true,
+		},
+		{
+			name:   "GET request with expired token",
+			method: http.MethodGet,
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+			},
+			tokenRefreshTime:   time.Now().Add(-13 * time.Hour),
+			wantStatus:         http.StatusOK,
+			wantHasToken:       true,
+			wantIsExpired:      true,
+			checkHoursUntilExp: false,
+		},
+		{
+			name:             "POST request should fail",
+			method:           http.MethodPost,
+			token:            &oauth2.Token{AccessToken: "test-token"},
+			tokenRefreshTime: time.Now(),
+			wantStatus:       http.StatusMethodNotAllowed,
+		},
+		{
+			name:             "PUT request should fail",
+			method:           http.MethodPut,
+			token:            &oauth2.Token{AccessToken: "test-token"},
+			tokenRefreshTime: time.Now(),
+			wantStatus:       http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := logging.NewLogger(logging.LogLevel("error"), nil)
+			irc := &IRC{
+				tok:              tt.token,
+				tokenRefreshTime: tt.tokenRefreshTime,
+				logger:           logger,
+			}
+
+			req := httptest.NewRequest(tt.method, "/healthz/auth", nil)
+			w := httptest.NewRecorder()
+
+			handler := irc.AuthHealthHandler()
+			handler(w, req)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("Status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			// Only check JSON response for successful GET requests
+			if tt.method == http.MethodGet && tt.wantStatus == http.StatusOK {
+				var health AuthHealthResponse
+				if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+					t.Fatalf("Failed to decode response: %v", err)
+				}
+
+				if health.HasToken != tt.wantHasToken {
+					t.Errorf("HasToken = %v, want %v", health.HasToken, tt.wantHasToken)
+				}
+
+				if health.IsExpired != tt.wantIsExpired {
+					t.Errorf("IsExpired = %v, want %v", health.IsExpired, tt.wantIsExpired)
+				}
+
+				if tt.checkHoursUntilExp && health.HoursUntilExpiry <= 0 {
+					t.Errorf("HoursUntilExpiry should be positive, got %f", health.HoursUntilExpiry)
+				}
+
+				// Verify content type
+				contentType := resp.Header.Get("Content-Type")
+				if contentType != "application/json" {
+					t.Errorf("Content-Type = %s, want application/json", contentType)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthHealthResponse200Status(t *testing.T) {
+	logger := logging.NewLogger(logging.LogLevel("error"), nil)
+	irc := &IRC{
+		tok: &oauth2.Token{
+			AccessToken: "valid-token",
+		},
+		tokenRefreshTime: time.Now(),
+		logger:           logger,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/auth", nil)
+	w := httptest.NewRecorder()
+
+	handler := irc.AuthHealthHandler()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var response AuthHealthResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	// Verify the payload structure
+	if !response.HasToken {
+		t.Error("Expected HasToken to be true")
+	}
+
+	if response.LastRefreshTime.IsZero() {
+		t.Error("LastRefreshTime should not be zero")
+	}
+
+	if response.ExpirationTime.IsZero() {
+		t.Error("ExpirationTime should not be zero")
+	}
+}
+
+func TestAuthHealthResponseFailure(t *testing.T) {
+	logger := logging.NewLogger(logging.LogLevel("error"), nil)
+	irc := &IRC{
+		tok:              nil, // No token
+		tokenRefreshTime: time.Time{},
+		logger:           logger,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/auth", nil)
+	w := httptest.NewRecorder()
+
+	handler := irc.AuthHealthHandler()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 even with no token, got %d", w.Code)
+	}
+
+	var response AuthHealthResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if response.HasToken {
+		t.Error("Expected HasToken to be false when no token present")
+	}
+
+	if response.IsExpired != true {
+		t.Error("Expected IsExpired to be true when no token present")
+	}
+}

--- a/twitch/connection.go
+++ b/twitch/connection.go
@@ -3,6 +3,7 @@ package twitchirc
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/Soypete/twitch-llm-bot/ai"
 	"github.com/Soypete/twitch-llm-bot/database"
@@ -23,6 +24,7 @@ type IRC struct {
 	wg               *sync.WaitGroup
 	Client           *v2.Client
 	tok              *oauth2.Token
+	tokenRefreshTime time.Time        // Time when the token was last refreshed
 	llm              ai.Chatter
 	authCode         string
 	logger           *logging.Logger


### PR DESCRIPTION
## Summary

Adds `/healthz/auth` endpoint to Twitch bot that tracks OAuth token expiration (12-hour lifetime) and extends the keepalive service to monitor token health and send Discord alerts.

## Changes

### Twitch Bot
- Added `/healthz/auth` endpoint (port 6061) that returns:
  - Token presence status
  - Last refresh timestamp
  - Expiration time (12 hours from refresh)
  - Hours until expiry
- Track `tokenRefreshTime` in IRC struct for accurate expiration calculation
- Comprehensive test suite covering success (200), payload validation, and failure scenarios

### KeepAlive Service
- Extended to query Twitch bot's `/healthz/auth` endpoint
- Sends Discord alerts when token will expire within 12 hours
- Sends Discord alerts when token has expired
- Respects alert interval (defaults to 1 hour) to prevent spam
- Configurable via `TWITCH_BOT_AUTH_URL` environment variable

## Test Plan

- [x] All auth health endpoint tests pass (`TestAuthHealth*`)
- [x] Tests cover 200 OK responses with valid payload
- [x] Tests cover expired token detection
- [x] Tests cover no token scenario
- [x] Tests cover HTTP method validation (only GET allowed)
- [x] Code builds successfully (`go build ./...`)

## Future Work

- Added TODO for automated reauth endpoint once k8s deployment is set up
- This will allow keepalive to trigger token refresh automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)