### PR TITLE
Remove GoWest conference mode from Twitch bot

### DIFF
--- a/ai/chatter.go
+++ b/ai/chatter.go
@@ -11,45 +11,6 @@ import (
 
 var PedroPrompt = "Your name is Pedro. You are a chat bot that helps out in SoyPeteTech's twitch chat. Today's date is %s. SoyPeteTech is a Software Streamer (Aka Miriah Peterson) who's streams consist of live coding primarily in Golang or Data/AI meetups. She is a self taught developer based in Utah, USA and is employeed a Member of Technical Staff at a startup. If someone addresses you by name please respond by answering the question to the best of you ability. Do not use links, but you can use code, or emotes to express fun messages about software. If you are unsure about current events, news, or need to look up recent information, respond with exactly 'execute web search' followed by your suggested search query. If the chat user is being rude or inappropriate please ignore them. Keep your responses fun and engaging. Here are some approved emotes soypet2Thinking soypet2Dance soypet2ConfusedPedro soypet2SneakyDevil soypet2Hug soypet2Winning soypet2Love soypet2Peace soypet2Brokepedro soypet2Profpedro soypet2HappyPedro soypet2Max soypet2Loulou soypet2Thinking soypet2Pray soypet2Lol. Do not exceed 500 characters. Do not use new lines. Do not use leet speak or l33t speak. Do not talk about Java or Javascript! Have fun!"
 
-// GoWestAddendum is additional context for the GoWest conference (October 24, 2025)
-// This paragraph can be appended to PedroPrompt when -gowestMode is enabled
-// REMOVE THIS SECTION AFTER THE CONFERENCE
-var GoWestAddendum = `
-
-SPECIAL EVENT TODAY - GoWest Conference (October 24, 2025):
-We are streaming the GoWest Go programming conference live! Help viewers learn about the event.
-
-Conference Schedule:
-- 9:30 AM: Registration & Breakfast
-- 10:00 AM: Opening Ceremony
-- 10:15 AM: "Building Production Grade AI in Go: a Live Post-mortem" by Miriah Peterson (SoyPeteTech)
-- 10:45 AM: Break
-- 11:00 AM: "Fundamentals of Memory Management in Go" by Takuto Nagami
-- 11:30 AM: "Spot the Nil Dereference: How to avoid a billion-dollar mistake" by Arseniy Terekhov
-- 12:00 PM: Lunch
-- 1:00 PM: Lightning Talks (sign up: https://docs.google.com/forms/d/e/1FAIpQLSfKUq8kMkwKgvEhSz5ySgCh3edw6Gir3udu8OPlN74590VAKQ/viewform - in-person only)
-- 2:00 PM: "Conduit: Real-Time Data Streams Made Simple" by William Hill
-- 2:30 PM: "Go Channels Demystified"
-- 3:00 PM: Snack Break
-- 3:30 PM: Community Session - "The Go Standard Library vs. Open Source Tools" by Elliot Minns & Shane Hansen
-- 4:00 PM: "The basics of go/ast for people who can't even spell ast" by Carson Anderson
-- 4:30 PM: "You're already running my code in production: My journey to become a Go contributor" by Jonathan Hall
-- 5:00 PM: Raffle & After Party
-
-Streaming Platforms:
-- Forge Utah YouTube: https://youtube.com/live/qKH3aT0owF8
-- SoyPeteTech Twitch: twitch.tv/soypetetech (you are here!)
-
-Important Links:
-- Conference Website: gowestconf.com
-- Forge Utah Community: forgeutah.tech (join the Slack!)
-- SoyPeteTech: soypetetech.com
-
-Location: Weave HQ in Lehi, Utah (in-person) + Virtual streaming
-
-When people ask about the conference, schedule, talks, or how to get involved, use this information. Be enthusiastic about the Go community! soypet2Dance
-`
-
 // Chattter is the interface that defines the functions that Pedro will have. The interface is implemented with functionally for each connection.
 type Chatter interface {
 	SingleMessageResponse(ctx context.Context, msg types.TwitchMessage, messageID uuid.UUID) (types.TwitchMessage, error)

--- a/ai/twitchchat/llm.go
+++ b/ai/twitchchat/llm.go
@@ -30,13 +30,7 @@ func (c *Client) callLLM(ctx context.Context, injection []string, messageID uuid
 	now := time.Now().Format(time.DateOnly)
 	c.manageChatHistory(ctx, injection, llms.ChatMessageTypeHuman)
 
-	// Build system prompt with optional GoWest addendum
 	systemPrompt := fmt.Sprintf(ai.PedroPrompt, now)
-	if c.gowestMode {
-		systemPrompt += ai.GoWestAddendum
-		c.logger.Debug("using GoWest enhanced prompt")
-	}
-
 	messageHistory := []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeSystem, systemPrompt)}
 	messageHistory = append(messageHistory, c.chatHistory...)
 
@@ -153,12 +147,7 @@ func (c *Client) ExecuteWebSearch(ctx context.Context, request *types.WebSearchR
 
 	now := time.Now().Format(time.DateOnly)
 
-	// Build system prompt with optional GoWest addendum
 	systemPrompt := fmt.Sprintf(ai.PedroPrompt, now)
-	if c.gowestMode {
-		systemPrompt += ai.GoWestAddendum
-	}
-
 	messageHistory := []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeSystem, systemPrompt)}
 	// messageHistory = append(messageHistory, request.ChatHistory...)
 	messageHistory = append(messageHistory, llms.TextParts(llms.ChatMessageTypeSystem,

--- a/ai/twitchchat/setup.go
+++ b/ai/twitchchat/setup.go
@@ -17,11 +17,10 @@ type Client struct {
 	modelName   string
 	logger      *logging.Logger
 	ddgClient   *duckduckgo.Client
-	gowestMode  bool
 }
 
 // Setup creates a new twitch chat bot.
-func Setup(llmPath string, modelName string, gowestMode bool, logger *logging.Logger) (*Client, error) {
+func Setup(llmPath string, modelName string, logger *logging.Logger) (*Client, error) {
 	if logger == nil {
 		logger = logging.Default()
 	}
@@ -47,15 +46,10 @@ func Setup(llmPath string, modelName string, gowestMode bool, logger *logging.Lo
 	// Initialize DuckDuckGo client
 	ddgClient := duckduckgo.NewClient()
 
-	if gowestMode {
-		logger.Info("GoWest conference mode enabled")
-	}
-
 	return &Client{
-		llm:        llm,
-		modelName:  modelName,
-		logger:     logger,
-		ddgClient:  ddgClient,
-		gowestMode: gowestMode,
+		llm:       llm,
+		modelName: modelName,
+		logger:    logger,
+		ddgClient: ddgClient,
 	}, nil
 }

--- a/cli/twitch/twitch.go
+++ b/cli/twitch/twitch.go
@@ -17,11 +17,9 @@ import (
 func main() {
 	var model string
 	var logLevel string
-	var gowestMode bool
 
 	flag.StringVar(&model, "model", os.Getenv("MODEL"), "The model to use for the LLM")
 	flag.StringVar(&logLevel, "errorLevel", "info", "Log level (debug, info, warn, error)")
-	flag.BoolVar(&gowestMode, "gowestMode", false, "Enable GoWest conference mode with enhanced prompt")
 	flag.Parse()
 
 	// Initialize logger
@@ -48,7 +46,7 @@ func main() {
 	//  we are not actually connecting to openai, but we are using their api spec to connect to our own model via llama.cpp
 	_ = os.Setenv("OPENAI_API_KEY", "test")
 	llmPath := os.Getenv("LLAMA_CPP_PATH")
-	twitchllm, err := twitchchat.Setup(llmPath, model, gowestMode, logger)
+	twitchllm, err := twitchchat.Setup(llmPath, model, logger)
 	if err != nil {
 		logger.Error("failed to setup twitch LLM", "error", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Removed the `--gowestMode` CLI flag and all related GoWest conference functionality
- The flag wasn't working correctly (applied the GoWest prompt even when set to `false`)
- Since the conference is over, completely removed the feature instead of fixing it

## Changes
- Removed `--gowestMode` CLI flag from `cli/twitch/twitch.go`
- Removed `gowestMode` parameter from `twitchchat.Setup()` function signature
- Removed `gowestMode` field from `twitchchat.Client` struct
- Removed `GoWestAddendum` constant from `ai/chatter.go`
- Removed conditional logic in `callLLM()` and `ExecuteWebSearch()` that appended GoWest prompt

## Impact
Pedro now returns to his standard personality without any conference-specific context. The bot will respond normally without GoWest conference information.

## Test plan
- [ ] Build the Twitch bot successfully
- [ ] Run the bot locally and verify it responds normally
- [ ] Verify no GoWest conference context appears in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)