### PR TITLE
fix: keepalive alerts only when token expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,4 @@ sudo systemctl restart pedro-discord
 sudo systemctl restart pedro-twitch
 ```
 
+# Keepalive token expiry alerts


### PR DESCRIPTION
Update keepalive bot to only send Discord alerts when Twitch token is expired, not for all offline events