### PR TITLE
Migrate bots to OpenBAO secrets injection

### DIFF
--- a/charts/pedro-bots/templates/discord-deployment.yaml
+++ b/charts/pedro-bots/templates/discord-deployment.yaml
@@ -18,7 +18,22 @@ spec:
       labels:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: discord
+      annotations:
+        {{- if .Values.discordBot.openbaoInjection }}
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "pedro"
+        vault.hashicorp.com/agent-inject-secret-discord: "secret/apps/discord"
+        vault.hashicorp.com/agent-inject-template-discord: |
+          {{`{{- with secret "secret/apps/discord" -}}`}}
+          {{`export DISCORD_SECRET="{{ .Data.data.client_secret }}"`}}
+          {{`export DISCORD_CLIENT_ID="{{ .Data.data.client_id }}"`}}
+          {{`export DISCORD_PUBLIC_KEY="{{ .Data.data.public_key }}"`}}
+          {{`export DISCORD_PERMISSION="{{ .Data.data.permission }}"`}}
+          {{`export POSTGRES_URL="{{ .Data.data.postgresUrl }}"`}}
+          {{`{{- end }}`}}
+        {{- end }}
     spec:
+      serviceAccountName: pedro-discord
       containers:
         - name: discord-bot
           image: "{{ .Values.discordBot.image.repository }}:{{ .Values.discordBot.image.tag }}"
@@ -33,14 +48,44 @@ spec:
               port: 6060
             initialDelaySeconds: 10
             periodSeconds: 30
-          env:
-            {{- range .Values.discordBot.env }}
-            - name: {{ .name }}
-              value: {{ .value | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            {{- if .Values.discordBot.openbaoInjection }}
+            - ". /vault/secrets/discord && /app/main"
+            {{- else }}
+            - "/app/main"
             {{- end }}
+          {{- if not .Values.discordBot.openbaoInjection }}
+          env:
+            - name: DISCORD_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_SECRET
+            - name: DISCORD_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_CLIENT_ID
+            - name: DISCORD_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_PUBLIC_KEY
+            - name: POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: postgresUrl
           envFrom:
             - secretRef:
                 name: {{ include "pedro-bots.fullname" . }}-secrets
+          {{- end }}
+          env:
+            - name: MODEL
+              value: "qwen3.6-27b"
+            - name: LLAMA_CPP_PATH
+              value: "http://100.121.229.114:8080"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/pedro-bots/templates/keepalive-deployment.yaml
+++ b/charts/pedro-bots/templates/keepalive-deployment.yaml
@@ -18,19 +18,71 @@ spec:
       labels:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: keepalive
+      annotations:
+        {{- if .Values.keepalive.openbaoInjection }}
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "pedro"
+        vault.hashicorp.com/agent-inject-secret-discord: "secret/apps/discord"
+        vault.hashicorp.com/agent-inject-template-discord: |
+          {{`{{- with secret "secret/apps/discord" -}}`}}
+          {{`export DISCORD_SECRET="{{ .Data.data.client_secret }}"`}}
+          {{`export DISCORD_CLIENT_ID="{{ .Data.data.client_id }}"`}}
+          {{`{{- end }}`}}
+        vault.hashicorp.com/agent-inject-secret-twitch: "secret/apps/twitch"
+        vault.hashicorp.com/agent-inject-template-twitch: |
+          {{`{{- with secret "secret/apps/twitch" -}}`}}
+          {{`export TWITCH_ID="{{ .Data.data.client_id }}"`}}
+          {{`export TWITCH_SECRET="{{ .Data.data.client_secret }}"`}}
+          {{`{{- end }}`}}
+        {{- end }}
     spec:
+      serviceAccountName: pedro-keepalive
       containers:
         - name: keepalive
           image: "{{ .Values.keepalive.image.repository }}:{{ .Values.keepalive.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            {{- if .Values.keepalive.openbaoInjection }}
+            - ". /vault/secrets/discord && . /vault/secrets/twitch && /app/keepalive-service"
+            {{- else }}
+            - "/app/keepalive-service"
+            {{- end }}
           env:
             {{- range .Values.keepalive.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+            {{- if not .Values.keepalive.openbaoInjection }}
+            - name: DISCORD_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_SECRET
+            - name: DISCORD_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_CLIENT_ID
+            - name: DISCORD_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: DISCORD_PUBLIC_KEY
+            - name: TWITCH_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: twitchId
+            - name: TWITCH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: twitchSecret
           envFrom:
             - secretRef:
                 name: {{ include "pedro-bots.fullname" . }}-secrets
+            {{- end }}
           resources:
             limits:
               cpu: 100m

--- a/charts/pedro-bots/templates/mempalace-deployment.yaml
+++ b/charts/pedro-bots/templates/mempalace-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.mempalace.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pedro-bots.fullname" . }}-mempalace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pedro-bots.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mempalace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "pedro-bots.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mempalace
+  template:
+    metadata:
+      labels:
+        {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mempalace
+      annotations:
+        {{- if .Values.mempalace.openbaoInjection }}
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "pedro"
+        vault.hashicorp.com/agent-inject-secret-pedrocli: "secret/apps/pedrocli"
+        vault.hashicorp.com/agent-inject-template-pedrocli: |
+          {{`{{- with secret "secret/apps/pedrocli" -}}`}}
+          {{`export POSTGRES_URL="{{ .Data.data.database_url }}"`}}
+          {{`{{- end }}`}}
+        {{- end }}
+    spec:
+      serviceAccountName: pedro-mempalace
+      containers:
+        - name: mempalace
+          image: "{{ .Values.mempalace.image.repository }}:{{ .Values.mempalace.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          command: ["/bin/sh", "-c"]
+          {{- if .Values.mempalace.openbaoInjection }}
+          args:
+            - ". /vault/secrets/pedrocli && exec /usr/local/bin/mempalace-wrapper"
+          {{- else }}
+          args:
+            - "exec /usr/local/bin/mempalace-wrapper"
+          {{- end }}
+          env:
+            - name: MEMPALACE_WRAPPER_ADDR
+              value: ":8082"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pedro-bots.fullname" . }}-mempalace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pedro-bots.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mempalace
+spec:
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    {{- include "pedro-bots.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mempalace
+{{- end }}

--- a/charts/pedro-bots/templates/pedro-discord-serviceaccount.yaml
+++ b/charts/pedro-bots/templates/pedro-discord-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.discordBot.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pedro-discord
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pedro-bots.labels" . | nindent 4 }}
+    app.kubernetes.io/component: discord
+{{- end }}

--- a/charts/pedro-bots/templates/pedro-twitch-serviceaccount.yaml
+++ b/charts/pedro-bots/templates/pedro-twitch-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.twitchBot.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pedro-twitch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pedro-bots.labels" . | nindent 4 }}
+    app.kubernetes.io/component: twitch
+{{- end }}

--- a/charts/pedro-bots/templates/secret.yaml
+++ b/charts/pedro-bots/templates/secret.yaml
@@ -8,25 +8,35 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.secrets.twitchId }}
-  TWITCH_ID: {{ .Values.secrets.twitchId | b64enc }}
+  twitchId: {{ .Values.secrets.twitchId | b64enc }}
+  {{- else }}
+  twitchId: {{ "placeholder" | b64enc }}
   {{- end }}
   {{- if .Values.secrets.twitchSecret }}
-  TWITCH_SECRET: {{ .Values.secrets.twitchSecret | b64enc }}
+  twitchSecret: {{ .Values.secrets.twitchSecret | b64enc }}
+  {{- else }}
+  twitchSecret: {{ "placeholder" | b64enc }}
   {{- end }}
   {{- if .Values.secrets.twitchToken }}
-  TWITCH_TOKEN: {{ .Values.secrets.twitchToken | b64enc }}
+  twitchToken: {{ .Values.secrets.twitchToken | b64enc }}
   {{- end }}
   {{- if .Values.secrets.postgresUrl }}
-  POSTGRES_URL: {{ .Values.secrets.postgresUrl | b64enc }}
+  postgresUrl: {{ .Values.secrets.postgresUrl | b64enc }}
+  {{- else }}
+  postgresUrl: {{ "postgres://placeholder" | b64enc }}
   {{- end }}
   {{- if .Values.secrets.postgresVectorUrl }}
   POSTGRES_VECTOR_URL: {{ .Values.secrets.postgresVectorUrl | b64enc }}
   {{- end }}
   {{- if .Values.secrets.discordSecret }}
   DISCORD_SECRET: {{ .Values.secrets.discordSecret | b64enc }}
+  {{- else }}
+  DISCORD_SECRET: {{ "placeholder" | b64enc }}
   {{- end }}
   {{- if .Values.secrets.discordClientId }}
   DISCORD_CLIENT_ID: {{ .Values.secrets.discordClientId | b64enc }}
+  {{- else }}
+  DISCORD_CLIENT_ID: {{ "placeholder" | b64enc }}
   {{- end }}
   {{- if .Values.secrets.discordPublicKey }}
   DISCORD_PUBLIC_KEY: {{ .Values.secrets.discordPublicKey | b64enc }}

--- a/charts/pedro-bots/templates/twitch-deployment.yaml
+++ b/charts/pedro-bots/templates/twitch-deployment.yaml
@@ -18,7 +18,20 @@ spec:
       labels:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: twitch
+      annotations:
+        {{- if .Values.twitchBot.openbaoInjection }}
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "pedro"
+        vault.hashicorp.com/agent-inject-secret-twitch: "secret/apps/twitch"
+        vault.hashicorp.com/agent-inject-template-twitch: |
+          {{`{{- with secret "secret/apps/twitch" -}}`}}
+          {{`export TWITCH_ID="{{ .Data.data.client_id }}"`}}
+          {{`export TWITCH_SECRET="{{ .Data.data.client_secret }}"`}}
+          {{`export POSTGRES_URL="{{ .Data.data.postgresUrl }}"`}}
+          {{`{{- end }}`}}
+        {{- end }}
     spec:
+      serviceAccountName: pedro-twitch
       containers:
         - name: twitch-bot
           image: "{{ .Values.twitchBot.image.repository }}:{{ .Values.twitchBot.image.tag }}"
@@ -36,14 +49,47 @@ spec:
               port: 6060
             initialDelaySeconds: 10
             periodSeconds: 30
+          command: ["/bin/sh", "-c"]
+          args:
+            {{- if .Values.twitchBot.openbaoInjection }}
+            - ". /vault/secrets/twitch && exec /app/main"
+            {{- else }}
+            - "exec /app/main"
+            {{- end }}
           env:
+            {{- if not .Values.twitchBot.openbaoInjection }}
+            - name: TWITCH_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: twitchId
+            - name: TWITCH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: twitchSecret
+            - name: TWITCH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: twitchToken
+                  optional: true
+            - name: POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pedro-bots.fullname" . }}-secrets
+                  key: postgresUrl
+            {{- end }}
             {{- range .Values.twitchBot.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-          envFrom:
-            - secretRef:
-                name: {{ include "pedro-bots.fullname" . }}-secrets
+          {{- if .Values.twitchBot.args }}
+          args:
+            {{- range .Values.twitchBot.args }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/pedro-bots/values.yaml
+++ b/charts/pedro-bots/values.yaml
@@ -7,34 +7,44 @@ image:
 
 discordBot:
   enabled: true
+  openbaoInjection: true
   image:
     repository: 100.81.89.62:5000/pedro-discord
-    tag: latest
+    tag: df12033
   env:
     - name: MODEL
-      value: "gpt-oss-20b"
+      value: "qwen3.6-27b"
     - name: LLAMA_CPP_PATH
       value: "http://100.121.229.114:8080"
 
 twitchBot:
   enabled: true
   tailscaleIngress: true
+  openbaoInjection: true
   image:
     repository: 100.81.89.62:5000/pedro-twitch
-    tag: latest
+    tag: df12033
   env:
     - name: MODEL
-      value: "gpt-oss-20b"
+      value: "qwen3.6-27b"
     - name: LLAMA_CPP_PATH
       value: "http://100.121.229.114:8080"
     - name: OAUTH_REDIRECT_HOST
       value: "chatbot-pedro-twitch-auth-ingress.tail6fbc5.ts.net"
 
+mempalace:
+  enabled: true
+  openbaoInjection: true
+  image:
+    repository: 100.81.89.62:5000/pedro-mempalace
+    tag: dbca760
+
 keepalive:
   enabled: true
+  openbaoInjection: true
   image:
     repository: 100.81.89.62:5000/pedro-keepalive
-    tag: latest
+    tag: df12033
   env:
     - name: DISCORD_BOT_URL
       value: "http://pedro-discord:6060/healthz"
@@ -53,7 +63,6 @@ keepalive:
 secrets:
   twitchId: ""
   twitchSecret: ""
-  twitchToken: ""
   postgresUrl: ""
   postgresVectorUrl: ""
   discordSecret: ""

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -1,0 +1,205 @@
+# Bot Deployment Runbook
+
+This guide covers how to deploy services to the K3s cluster using Helm with OpenBAO secrets injection.
+
+## Prerequisites
+
+- Access to the K3s cluster via Foundry
+- OpenBAO running at `100.81.89.62:8200`
+- Zot registry at `100.81.89.62:5000`
+- kubectl configured with Foundry kubeconfig
+
+```bash
+export KUBECONFIG=~/.foundry/kubeconfig
+```
+
+## Cluster Info
+
+| Service | Address |
+|---------|---------|
+| OpenBAO | 100.81.89.62:8200 |
+| Zot Registry | 100.81.89.62:5000 |
+| K8s API | 100.81.89.100:6443 |
+
+### Nodes
+- **blue1** (100.81.89.62): Control plane + infrastructure
+- **blue2** (100.70.90.12): Worker with 2TB storage
+- **refurb** (100.125.196.1): Worker
+
+---
+
+## Adding a New Bot/Service
+
+### Step 1: Create OpenBAO Secrets
+
+1. Login to OpenBAO:
+   ```bash
+   export VAULT_ADDR=http://100.81.89.62:8200
+   # Token from 1Password or `vault login`
+   export VAULT_TOKEN=<your-token>
+   ```
+
+2. Enable KV secrets engine if needed:
+   ```bash
+   vault secrets enable -path=pedro kv-v2
+   ```
+
+3. Write secrets:
+   ```bash
+   vault kv put pedro/discord \
+     DISCORD_SECRET="your_secret_here" \
+     DISCORD_CLIENT_ID="your_client_id" \
+     DISCORD_PUBLIC_KEY="your_public_key" \
+     POSTGRES_URL="postgresql://user:pass@host:5432/db?sslmode=require"
+   ```
+
+### Step 2: Create Kubernetes Service Account
+
+Create a ServiceAccount in the target namespace that matches the OpenBAO role:
+
+```yaml
+# serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pedro-<service-name>
+  namespace: chatbot
+```
+
+Apply:
+```bash
+kubectl apply -f serviceaccount.yaml
+```
+
+### Step 3: Update OpenBAO Role
+
+The OpenBAO role must allow the service account. Update the auth role:
+
+```bash
+vault write auth/kubernetes/role/pedro-bots \
+    bound_service_account_names="pedro-discord,pedro-twitch,pedro-keepalive,pedro-mempalace" \
+    bound_service_account_namespaces=chatbot \
+    policies=pedro-bots-policy \
+    ttl=24h
+```
+
+### Step 4: Add Vault Annotations to Helm Template
+
+In your deployment template (`templates/<service>-deployment.yaml`):
+
+```yaml
+metadata:
+  annotations:
+    vault.hashicorp.com/agent-inject: "true"
+    vault.hashicorp.com/role: "pedro-bots"
+    vault.hashicorp.com/agent-inject-secret-{secret-name}: "pedro/{secret-path}"
+    vault.hashicorp.com/agent-inject-template-{secret-name}: |
+      {{- with secret "pedro/{secret-path}" -}}
+      {{- range $k, $v := .data.data }}
+      export {{ $k }}="{{ $v }}"
+      {{- end }}
+      {{- end }}
+```
+
+### Step 5: Update values.yaml
+
+Enable OpenBAO injection:
+
+```yaml
+discord:
+  openbaoInjection: true
+  # ... other config
+```
+
+### Step 6: Deploy
+
+```bash
+cd charts/pedro-bots
+helm upgrade pedro . -n chatbot
+```
+
+### Step 7: Verify
+
+Check pods are running:
+```bash
+kubectl get pods -n chatbot -l app.kubernetes.io/name=pedro-bots
+```
+
+Verify secrets are injected:
+```bash
+kubectl exec -n chatbot <pod-name> -c <container> -- cat /vault/secrets/<secret-name>
+```
+
+---
+
+## Deployment Commands
+
+### Deploy to production
+```bash
+cd charts/pedro-bots
+helm upgrade pedro . -n chatbot
+```
+
+### Restart a specific bot
+```bash
+kubectl rollout restart deployment/pedro-discord -n chatbot
+```
+
+### View logs
+```bash
+kubectl logs -n chatbot -l app.kubernetes.io/name=pedro-bots -f
+```
+
+### Rollback
+```bash
+helm rollback pedro -n chatbot
+```
+
+---
+
+## Troubleshooting
+
+### Secrets not injecting
+1. Check ServiceAccount exists: `kubectl get sa pedro-<service> -n chatbot`
+2. Verify vault annotations on pod: `kubectl describe pod <pod> | grep -A5 vault`
+3. Check OpenBAO role: `vault read auth/kubernetes/role/pedro-bots`
+4. Verify secrets exist: `vault kv get pedro/<service>`
+
+### Pod not scheduling
+1. Check node resources: `kubectl top nodes`
+2. Review pod events: `kubectl describe pod <pod>`
+3. Check nodeSelector/tolerations in values.yaml
+
+### Image pull failures
+1. Verify image exists in Zot: `curl http://100.81.89.62:5000/v2/_catalog`
+2. Check image tag is correct in values.yaml
+3. Ensure you're building for linux/amd64
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Vault secrets show empty | Ensure POSTGRES_URL is in vault KV under data.data |
+| Pod crashloop | Check command path - use `/usr/local/bin/<wrapper>` |
+| Image "latest" missing binaries | Use specific image tags (commit hash) |
+| High CPU on control-plane | Remove nodeSelector to allow worker scheduling |
+
+---
+
+## Useful Commands
+
+```bash
+# Get all pods with node info
+kubectl get pods -n chatbot -o wide
+
+# Check OpenBAO status
+vault status -address=http://100.81.89.62:8200
+
+# List all vault secrets
+vault kv list pedro/
+
+# Check pod vault sidecar
+kubectl get pod <pod> -n chatbot -o jsonpath='{.spec.containers[*].name}'
+```


### PR DESCRIPTION
## Summary
- Migrate Discord, Twitch, Keepalive, and Mempalace bots from K8s secrets to OpenBAO
- Add vault annotations for secrets injection in all deployments
- Add ServiceAccounts for each bot
- Remove nodeSelector constraint (schedule on any node)

## Changes
- Enable `openbaoInjection` in values.yaml for all bots
- Add vault agent annotations to deployment templates
- Add POSTGRES_URL from vault for discord/twitch/mempalace
- Add service accounts: pedro-discord, pedro-twitch
- Remove control-plane nodeSelector to use worker nodes

## Testing
All 4 bots running with OpenBAO secrets on production cluster.