### PR TITLE
fix: update workflow Go version and golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.24
+        go-version: "1.26"
 
-    - name: Build build twitch
+    - name: Build twitch
       run: go build -v -o pedro ./cli/twitch
 
   lint:  
@@ -43,12 +43,12 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.24
+        go-version: "1.26"
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4 
+      uses: golangci/golangci-lint-action@v9
       with:
         only-new-issues: true
-        skip-cache: true
+        version: latest
 
   test: 
     runs-on: ubuntu-latest
@@ -58,6 +58,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.24
+        go-version: "1.26"
     - name: Go Test
       run: go test ./... -v -cover -covermode=atomic


### PR DESCRIPTION
Cherry-picked from mem-palace branch.

## Summary
- Update workflow Go version to 1.26
- Use latest golangci-lint version in CI
- Update golangci-lint action to v9