### PR TITLE
infra: add Vault/OpenBAO agent injection and Helm updates

### DIFF
--- a/charts/pedro-bots/templates/discord-deployment.yaml
+++ b/charts/pedro-bots/templates/discord-deployment.yaml
@@ -19,8 +19,6 @@ spec:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: discord
       annotations:
-<<<<<<< HEAD
-        {{- if .Values.discordBot.openbaoInjection }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "pedro"
         vault.hashicorp.com/agent-inject-secret-discord: "secret/apps/discord"
@@ -30,11 +28,7 @@ spec:
           {{`export DISCORD_CLIENT_ID="{{ .Data.data.client_id }}"`}}
           {{`export DISCORD_PUBLIC_KEY="{{ .Data.data.public_key }}"`}}
           {{`export DISCORD_PERMISSION="{{ .Data.data.permission }}"`}}
-          {{`export POSTGRES_URL="{{ .Data.data.postgresUrl }}"`}}
           {{`{{- end }}`}}
-        {{- end }}
-=======
->>>>>>> bd8afa8 (Fix deployment: use explicit env vars instead of vault/envFrom)
     spec:
       serviceAccountName: pedro-discord
       containers:
@@ -51,58 +45,14 @@ spec:
               port: 6060
             initialDelaySeconds: 10
             periodSeconds: 30
-<<<<<<< HEAD
-command: ["/bin/sh", "-c"]
+          command: ["/bin/sh", "-c"]
           args:
-            {{- if .Values.discordBot.openbaoInjection }}
-            - ". /vault/secrets/discord && /app/main"
-            {{- else }}
-            - "/app/main"
-            {{- end }}
+            - ". /vault/secrets/discord && exec /app/discord"
           env:
-            - name: DISCORD_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_SECRET
-            - name: DISCORD_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_CLIENT_ID
-            - name: DISCORD_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_PUBLIC_KEY
-<<<<<<< HEAD
-=======
-            - name: MODEL
-              value: "qwen3.6-27b"
-            - name: LLAMA_CPP_PATH
-              value: "http://100.121.229.114:8080"
->>>>>>> bd8afa8 (Fix deployment: use explicit env vars instead of vault/envFrom)
-            - name: POSTGRES_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: postgresUrl
-          envFrom:
-            - secretRef:
-                name: {{ include "pedro-bots.fullname" . }}-secrets
-<<<<<<< HEAD
-          {{- end }}
-          env:
-            - name: MODEL
-              value: "qwen3.6-27b"
-            - name: LLAMA_CPP_PATH
-              value: "http://100.121.229.114:8080"
             {{- range .Values.discordBot.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-=======
->>>>>>> bd8afa8 (Fix deployment: use explicit env vars instead of vault/envFrom)
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/pedro-bots/templates/keepalive-deployment.yaml
+++ b/charts/pedro-bots/templates/keepalive-deployment.yaml
@@ -18,75 +18,37 @@ spec:
       labels:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: keepalive
-<<<<<<< HEAD
+      {{- if .Values.keepalive.openbaoInjection }}
       annotations:
-        {{- if .Values.keepalive.openbaoInjection }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "pedro"
         vault.hashicorp.com/agent-inject-secret-discord: "secret/apps/discord"
         vault.hashicorp.com/agent-inject-template-discord: |
           {{`{{- with secret "secret/apps/discord" -}}`}}
-          {{`export DISCORD_SECRET="{{ .Data.data.client_secret }}"`}}
-          {{`export DISCORD_CLIENT_ID="{{ .Data.data.client_id }}"`}}
+          {{`export DISCORD_BOT_URL="{{ .Data.data.client_id }}"`}}
           {{`{{- end }}`}}
         vault.hashicorp.com/agent-inject-secret-twitch: "secret/apps/twitch"
         vault.hashicorp.com/agent-inject-template-twitch: |
           {{`{{- with secret "secret/apps/twitch" -}}`}}
-          {{`export TWITCH_ID="{{ .Data.data.client_id }}"`}}
-          {{`export TWITCH_SECRET="{{ .Data.data.client_secret }}"`}}
+          {{`export TWITCH_BOT_URL="{{ .Data.data.client_id }}"`}}
           {{`{{- end }}`}}
-        {{- end }}
-=======
-      
->>>>>>> bd8afa8 (Fix deployment: use explicit env vars instead of vault/envFrom)
+      {{- end }}
     spec:
-      serviceAccountName: pedro-keepalive
       containers:
         - name: keepalive
           image: "{{ .Values.keepalive.image.repository }}:{{ .Values.keepalive.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
-            {{- if .Values.keepalive.openbaoInjection }}
             - ". /vault/secrets/discord && . /vault/secrets/twitch && exec /app/keepalive"
-            {{- else }}
-            - "/app/keepalive-service"
-            {{- end }}
           env:
             {{- range .Values.keepalive.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-            {{- if not .Values.keepalive.openbaoInjection }}
-            - name: DISCORD_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_SECRET
-            - name: DISCORD_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_CLIENT_ID
-            - name: DISCORD_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: DISCORD_PUBLIC_KEY
-            - name: TWITCH_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: twitchId
-            - name: TWITCH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: twitchSecret
           envFrom:
             - secretRef:
                 name: {{ include "pedro-bots.fullname" . }}-secrets
-            {{- end }}
           resources:
             limits:
               cpu: 100m

--- a/charts/pedro-bots/templates/twitch-deployment.yaml
+++ b/charts/pedro-bots/templates/twitch-deployment.yaml
@@ -19,7 +19,6 @@ spec:
         {{- include "pedro-bots.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: twitch
       annotations:
-        {{- if .Values.twitchBot.openbaoInjection }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "pedro"
         vault.hashicorp.com/agent-inject-secret-twitch: "secret/apps/twitch"
@@ -27,9 +26,12 @@ spec:
           {{`{{- with secret "secret/apps/twitch" -}}`}}
           {{`export TWITCH_ID="{{ .Data.data.client_id }}"`}}
           {{`export TWITCH_SECRET="{{ .Data.data.client_secret }}"`}}
-          {{`export POSTGRES_URL="{{ .Data.data.postgresUrl }}"`}}
           {{`{{- end }}`}}
-        {{- end }}
+        vault.hashicorp.com/agent-inject-secret-postgres: "secret/apps/postgres"
+        vault.hashicorp.com/agent-inject-template-postgres: |
+          {{`{{- with secret "secret/apps/postgres" -}}`}}
+          {{`export POSTGRES_URL="{{ .Data.data.url }}"`}}
+          {{`{{- end }}`}}
     spec:
       serviceAccountName: pedro-twitch
       containers:
@@ -51,35 +53,8 @@ spec:
             periodSeconds: 30
           command: ["/bin/sh", "-c"]
           args:
-            {{- if .Values.twitchBot.openbaoInjection }}
-            - ". /vault/secrets/twitch && exec /app/main"
-            {{- else }}
-            - "exec /app/main"
-            {{- end }}
+            - ". /vault/secrets/twitch && . /vault/secrets/postgres && exec /app/twitch"
           env:
-            {{- if not .Values.twitchBot.openbaoInjection }}
-            - name: TWITCH_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: twitchId
-            - name: TWITCH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: twitchSecret
-            - name: TWITCH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: twitchToken
-                  optional: true
-            - name: POSTGRES_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pedro-bots.fullname" . }}-secrets
-                  key: postgresUrl
-            {{- end }}
             {{- range .Values.twitchBot.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -90,9 +65,6 @@ spec:
             - {{ . | quote }}
             {{- end }}
           {{- end }}
-          envFrom:
-            - secretRef:
-                name: {{ include "pedro-bots.fullname" . }}-secrets
           volumeMounts:
             {{- if .Values.twitchBot.volumes }}
             {{- range .Values.twitchBot.volumes }}

--- a/charts/pedro-bots/values.yaml
+++ b/charts/pedro-bots/values.yaml
@@ -54,7 +54,7 @@ mempalace:
 
 keepalive:
   enabled: true
-  openbaoInjection: true
+  openbaoInjection: false
   image:
     repository: 100.81.89.62:5000/pedro-keepalive
     tag: df12033


### PR DESCRIPTION
Cherry-picked from mem-palace branch.

## Summary
- Add nodeSelector for control-plane nodes in helm charts
- Integrate Vault agent sidecar for secret injection
- Add OpenBAO agent injection support to helm charts
- Add Twitch OAuth flow documentation and fix K8s secret handling
- Fix deployment: use explicit env vars instead of vault/envFrom
- Remove PVC dependencies - use in-memory storage for mempalace
- Update mempalace image tag to amd64-fix