### PR TITLE
fix(keepalive): add health check logging and fix Helm template

### DIFF
--- a/charts/pedro-bots/templates/keepalive-deployment.yaml
+++ b/charts/pedro-bots/templates/keepalive-deployment.yaml
@@ -38,9 +38,13 @@ spec:
         - name: keepalive
           image: "{{ .Values.keepalive.image.repository }}:{{ .Values.keepalive.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.keepalive.openbaoInjection }}
           command: ["/bin/sh", "-c"]
           args:
-            - ". /vault/secrets/discord && . /vault/secrets/twitch && exec /app/keepalive"
+            - ". /vault/secrets/discord && . /vault/secrets/twitch && exec /app/keepalive-service"
+          {{- else }}
+          command: ["/app/keepalive-service"]
+          {{- end }}
           env:
             {{- range .Values.keepalive.env }}
             - name: {{ .name }}

--- a/charts/pedro-bots/values.yaml
+++ b/charts/pedro-bots/values.yaml
@@ -39,20 +39,22 @@ mempalace:
   image:
     repository: 100.81.89.62:5000/pedro-mempalace
     tag: dbca760
+  volume:
+    storageSize: "1Gi"
 
 keepalive:
   enabled: true
   openbaoInjection: false
   image:
     repository: 100.81.89.62:5000/pedro-keepalive
-    tag: df12033
+    tag: ce85152-v2
   env:
     - name: TWITCH_BOT_URL
       value: "http://pedro-twitch:6060/healthz"
     - name: TWITCH_BOT_AUTH_URL
       value: "http://pedro-twitch:6060/healthz/auth"
     - name: LLAMA_CPP_PATH
-      value: "http://100.121.229.114:8080"
+      value: "http://100.121.229.114:8000"
     - name: CHECK_INTERVAL
       value: "60"
     - name: ALERT_INTERVAL

--- a/cli/keepalive/main.go
+++ b/cli/keepalive/main.go
@@ -42,21 +42,25 @@ func main() {
 	logger := logging.NewLogger(logging.LogLevel(logLevel), os.Stdout)
 	stop := make(chan os.Signal, 1)
 
-	// Validate required token for Discord alerts
-	if discordToken == "" {
-		logger.Error("DISCORD_SECRET environment variable is required for alerts")
-		stop <- os.Interrupt
-	}
-
-	// Create Discord alerter for notifications
-	alerter, err := keepalive.NewDiscordAlerter(discordToken, discordUserID, logger)
-	if err != nil {
-		logger.Error("failed to create Discord alerter", "error", err.Error())
-		stop <- os.Interrupt
+	// Create alerter for notifications
+	// Use NoOpAlerter if Discord token is empty or placeholder
+	var alerter keepalive.Alerter
+	if discordToken == "" || discordToken == "placeholder" {
+		logger.Info("Discord alerts disabled - no valid token configured")
+		alerter = keepalive.NewNoOpAlerter()
+	} else {
+		var err error
+		alerter, err = keepalive.NewDiscordAlerter(discordToken, discordUserID, logger)
+		if err != nil {
+			logger.Error("failed to create Discord alerter, falling back to no-op", "error", err.Error())
+			alerter = keepalive.NewNoOpAlerter()
+		}
 	}
 	defer func() {
-		if err := alerter.Close(); err != nil {
-			stop <- os.Interrupt
+		if closer, ok := alerter.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				logger.Error("failed to close alerter", "error", err.Error())
+			}
 		}
 	}()
 

--- a/keepalive/noop_alerter.go
+++ b/keepalive/noop_alerter.go
@@ -1,0 +1,37 @@
+package keepalive
+
+import (
+	"context"
+	"fmt"
+)
+
+type NoOpAlerter struct{}
+
+func NewNoOpAlerter() *NoOpAlerter {
+	return &NoOpAlerter{}
+}
+
+func (n *NoOpAlerter) SendAlert(ctx context.Context, serviceName string, message string) error {
+	return nil
+}
+
+func (n *NoOpAlerter) Close() error {
+	return nil
+}
+
+type MockAlerter struct {
+	SentMessages []string
+}
+
+func NewMockAlerter() *MockAlerter {
+	return &MockAlerter{}
+}
+
+func (m *MockAlerter) SendAlert(ctx context.Context, serviceName string, message string) error {
+	m.SentMessages = append(m.SentMessages, fmt.Sprintf("[%s] %s", serviceName, message))
+	return nil
+}
+
+func (m *MockAlerter) Close() error {
+	return nil
+}

--- a/keepalive/service.go
+++ b/keepalive/service.go
@@ -14,8 +14,8 @@ import (
 
 // ServiceConfig represents configuration for a service to monitor
 type ServiceConfig struct {
-	Name         string
-	HealthURL    string
+	Name          string
+	HealthURL     string
 	AuthHealthURL string // Optional: URL to check auth token health (e.g., /healthz/auth)
 }
 
@@ -99,8 +99,9 @@ func (kas *KeepAliveService) Start(ctx context.Context) error {
 	ticker := time.NewTicker(kas.checkInterval)
 	defer ticker.Stop()
 
-	// Do an initial check immediately
+	// Do an initial check immediately and log results
 	kas.checkAllServices(ctx)
+	kas.logServiceStates("initial")
 
 	for {
 		select {
@@ -109,6 +110,7 @@ func (kas *KeepAliveService) Start(ctx context.Context) error {
 			return ctx.Err()
 		case <-ticker.C:
 			kas.checkAllServices(ctx)
+			kas.logServiceStates("periodic")
 		}
 	}
 }
@@ -365,4 +367,23 @@ func (kas *KeepAliveService) GetServiceStates() map[string]ServiceStateSnapshot 
 		svc.mu.RUnlock()
 	}
 	return states
+}
+
+// logServiceStates logs the current state of all services
+func (kas *KeepAliveService) logServiceStates(checkType string) {
+	states := kas.GetServiceStates()
+	for name, state := range states {
+		if state.IsHealthy {
+			kas.logger.Info("service health check passed",
+				"check_type", checkType,
+				"service", name,
+				"url", state.HealthURL)
+		} else {
+			kas.logger.Warn("service health check failed",
+				"check_type", checkType,
+				"service", name,
+				"url", state.HealthURL,
+				"consecutive_failures", state.ConsecutiveFailures)
+		}
+	}
 }


### PR DESCRIPTION
Summary:
- Add logServiceStates to log health of all services on startup and periodic checks
- Fix Helm template to conditionally use vault secrets only when openbaoInjection is enabled
- Add NoOpAlerter for when Discord token is missing/placeholder
- Change VLLM port from 8080 to 8000 in values.yaml

Fixes issue where keepalive was failing to start due to missing vault secrets when openbaoInjection is disabled.